### PR TITLE
Partial Fix for #227 Add -DMPIDE=23 Pre-Processor Option for gcc and g++

### DIFF
--- a/hardware/pic32/boards.txt
+++ b/hardware/pic32/boards.txt
@@ -4,7 +4,7 @@ uno_pic32.name=chipKIT UNO32
 # new items
 uno_pic32.platform=pic32
 uno_pic32.board=_BOARD_UNO_
-uno_pic32.compiler.define=-Danything_you_want::-Danything=1
+uno_pic32.compiler.define=-DMPIDE=23
 uno_pic32.ccflags=ffff
 uno_pic32.ldscript=chipKIT-UNO32-application-32MX320F128L.ld
 # end of new items
@@ -39,7 +39,7 @@ mega_pic32.name=chipKIT MAX32
 # new items
 mega_pic32.platform=pic32
 mega_pic32.board=_BOARD_MEGA_
-mega_pic32.compiler.define=-Danything_you_want
+mega_pic32.compiler.define=-DMPIDE=23
 mega_pic32.ccflags=ffff
 mega_pic32.ldscript=chipKIT-MAX32-application-32MX795F512L.ld
 # end of new items


### PR DESCRIPTION
Partial Fix for [#227](https://github.com/chipKIT32/chipKIT32-MAX/issues/227) Add -DMPIDE=23 Pre-Processor Option for gcc and g++

But new compiling trace still shows `-DARDUINO=23` as in

```
/Applications/mpide.app/Contents/Resources/Java/hardware/pic32/compiler/pic32-tools/bin/pic32-g++  
-O2  -c  -mno-smart-io  -w  -fno-exceptions  -ffunction-sections  -fdata-sections  -G1024  -g  -mdebugger  
-Wcast-align  -mprocessor=32MX320F128H  -DF_CPU=80000000L  
-DARDUINO=23  -D_BOARD_UNO_  -DMPIDE=23   
-I/Applications/Mpide.app/Contents/Resources/Java/examples/1.Basics/Blink   
-I/Applications/Mpide.app/Contents/Resources/Java/hardware/pic32/cores/pic32   
-I/Applications/Mpide.app/Contents/Resources/Java/hardware/pic32/variants/Uno32    
/var/tmp/Blink.cpp  -o  /var/folders/95/
```

Where does the `-DARDUINO=23` come from?
