### PR TITLE
Fixes issue #273

### DIFF
--- a/hardware/pic32/cores/pic32/HardwareSerial.h
+++ b/hardware/pic32/cores/pic32/HardwareSerial.h
@@ -63,7 +63,7 @@
 // is the index of the location from which to read.
 // The algorithms used to operate on the head and tail assume that the
 // size is a power of 2. (e.g. 32, 64, 128, etc)
-#define RX_BUFFER_SIZE 128
+#define RX_BUFFER_SIZE 512
 
 typedef struct {
 	unsigned char buffer[RX_BUFFER_SIZE];

--- a/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.c
+++ b/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.c
@@ -162,8 +162,8 @@ static byte			gTXbuffer[PACKET_SIZE];	// packet from host
 // N.B. -1 forces short packets
 static byte			gRXbuffer[NRX][PACKET_SIZE-1]; // packets to host
 static int			gRX_length[NRX];
-static byte			gRX_in;
-static byte			gRX_out;
+static volatile byte			gRX_in;
+static volatile byte			gRX_out;
 
 static boolean		gDiscard;	// true when we don't think anyone is listening
 

--- a/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.h
+++ b/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.h
@@ -4,6 +4,8 @@
 
 #include	"wiring.h"
 
+#define     USB_SERIAL_MIN_BUFFER_FREE      128
+
 extern boolean gCdcacm_active;
 
 typedef void (*cdcacm_reset_cbfn)(void);


### PR DESCRIPTION
....

Added code to tell USB stack to hold off when our serial buffer can't take more.
Upped the serial buffer size (for both USB and hardware - since they're not separate) to 512 bytes.
