### PR TITLE
Fixed math problem with Servo library that was incorrectly computing the...

### DIFF
--- a/hardware/pic32/libraries/Servo/Servo.h
+++ b/hardware/pic32/libraries/Servo/Servo.h
@@ -1,5 +1,5 @@
 /*
-  Servo.h - Interrupt driven Servo library for Arduino using 16 bit timers- Version 2
+  Servo.h - Interrupt driven Servo library for Arduino using 16 bit timers
   Copyright (c) 2009 Michael Margolis.  All right reserved.
   Revision date: 08/18/2011(Michelle Yu)
    
@@ -19,7 +19,6 @@
 */
 
 /* 
-  
   A servo is activated by creating an instance of the Servo class passing the desired pin to the attach() method.
   The servos are pulsed in the background using the value most recently written using the write() method
 
@@ -41,8 +40,24 @@
    readMicroseconds()   - Gets the last written servo pulse width in microseconds. (was read_us() in first release)
    attached()  - Returns true if there is a servo attached. 
    detach()    - Stops an attached servos from pulsing its i/o pin. 
+ 
+  This library has been modified to support the PIC32 architecture.
+ 
+  NOTE: On 09/18/2012 the code to disable a UART on pins 0 and 1 when
+  assigning a servo to those pins was removed, since not all boards have
+  UARTs on pins 0 and 1. You must be careful to disable any other function
+  on a given pin before you start using a servo output on that pin. For
+  example, if you have the standard UART on pins 1 and 0 and you want to use
+  those pins for servo output, you would need to disable the UART first.
+  Example:
+  Serial.end();
+  Servo.attach(0);
+ 
+  Version history:
+  See Servo.cpp
  */
 
+ 
 #ifndef Servo_h
 #define Servo_h
 
@@ -53,33 +68,17 @@
 
 #include <inttypes.h>
 
-/* 
- * Defines for 16 bit timers used with  Servo library 
- *
- * If _useTimerX is defined then TimerX is a 16 bit timer on the curent board
- * timer16_Sequence_t enumerates the sequence that the timers should be allocated
- * _Nbr_16timers indicates how many 16 bit timers are available.
- *
- */
-
-// Say which 16 bit timers can be used and in what order
-
-
-#define Servo_VERSION           3      // software version of this library
-
-#define SERVOS_PER_TIMER       8     // the maximum number of servos controlled by one timer 
-#define MAX_SERVOS             24
-
-
-#define MIN_PULSE_WIDTH       544     // the shortest pulse sent to a servo  (us)
+#define Servo_VERSION           3     // software version of this library
+#define SERVOS_PER_TIMER        8     // the maximum number of servos controlled by one timer 
+#define MAX_SERVOS             24     // Maximum number of servos this library can support at once
+#define MIN_PULSE_WIDTH       544     // the shortest pulse sent to a servo (us)
 #define MAX_PULSE_WIDTH      2400     // the longest pulse sent to a servo (us)
 #define DEFAULT_PULSE_WIDTH  1500     // default pulse width when servo is attached (us)
 #define REFRESH_INTERVAL    20000     // minumim time to refresh servos in microseconds 
-
 #define INVALID_SERVO         255     // flag indicating an invalid servo index
 
 typedef struct  {
-  uint8_t nbr        :6 ;             // a pin number from 0 to 63
+  uint8_t nbr        :7 ;             // a pin number from 0 to 127
   uint8_t isActive   :1 ;             // true if this channel is enabled, pin not pulsed if false 
 } ServoPin_t   ;  
 


### PR DESCRIPTION
... time between the last falling edge and the first rising edge of the next cycle.

Also tweaked timing so that pulses come out more accurately now.
Also changed code to support up to pin 127 (since MAX32 has 83 IOs, we needed to go above 63 which was the previous limit.)

Fix for issue #277
