### PR TITLE
Fixed intermittent OS X build issue with "chmod"

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -240,7 +240,7 @@
     </exec>
      
 <unzip dest="macosx/work/mpide.app/Contents/Resources/Java/hardware/pic32/compiler" src="macosx/dist/pic32-tools-chipKIT-cxx-master-Darwin-image-20120720.zip" overwrite="false"/>
-<chmod perm="+x" maxparallel=20>
+<chmod perm="+x" maxparallel="20">
       <fileset dir="macosx/work/mpide.app/Contents/Resources/Java/hardware/pic32/compiler" includes="**/*" />
 </chmod>
 


### PR DESCRIPTION
I set it so it will only try to chmod 20 filenames at a time when unzipping a file during building.  I didn't notice any extra delay or anything during build either.

This issue doesn't show up in my user shell on OS X, but it does on my Jenkins instance.  Either way, this doesn't seem like it would cause an issue anywhere, but it does solve the problems for Jenkins.
