### PR TITLE
Implemented Arduino 1.0.x flush() in HardwareSerial

### DIFF
--- a/hardware/pic32/cores/pic32/HardwareSerial.h
+++ b/hardware/pic32/cores/pic32/HardwareSerial.h
@@ -116,6 +116,7 @@ class HardwareSerial : public Stream
 		virtual int		peek();
 		virtual int		read(void);
 		virtual void	flush(void);
+		virtual void	purge(void);
 		virtual	void	write(uint8_t);
 		using	Print::write; // pull in write(str) and write(buf, size) from Print
 };

--- a/hardware/pic32/cores/pic32/p32_defs.h
+++ b/hardware/pic32/cores/pic32/p32_defs.h
@@ -121,6 +121,7 @@ typedef struct {
 */
 #define	_UARTSTA_URXEN	12
 #define	_UARTSTA_UTXEN	10
+#define _UARTSTA_UTXBF  9
 #define	_UARTSTA_TMRT	8
 
 /* Structure for the registers of a PIC32 SPI controller


### PR DESCRIPTION
The old flush() routine has been moved to purge()
The new flush() routine waits for the transmit shift register to be empty, then returns.
The write() function has been modified to wait if the TX FIFO is full instead of waiting if the TX shift register is full.  This automatically enables the use of the 4-or-8 level (depending on chip)  FIFO in the UART transmit system (alleviates the need for a transmit buffer like the Arduino 1.0.x has).  This should make transmitting of data somewhat more fluid.
