### PR TITLE
fixed serial to use more than just _SER0_VECTOR

### DIFF
--- a/hardware/pic32/cores/pic32/HardwareSerial.cpp
+++ b/hardware/pic32/cores/pic32/HardwareSerial.cpp
@@ -207,7 +207,7 @@ void HardwareSerial::begin(unsigned long baudRate)
     mapPps(pinRx, ppsRx);
 #endif
 
-    setIntVector(_SER0_VECTOR, isr);
+    setIntVector(vec, isr);
 
 	/* Set the interrupt privilege level and sub-privilege level
 	*/


### PR DESCRIPTION
As part of the Vector Manager update a bug was introduced so that only _SER0_VECTOR for all UARTs, updates so when a Serialx.begin() is called the appropriate vec is used for each UART. Effectively only the Serial monitor worked, no other Serial ports can be used without this fix.
