### PR TITLE
Switched CDC to using line status to determine endpoint presence.

### DIFF
--- a/hardware/pic32/cores/pic32/HardwareSerial.cpp
+++ b/hardware/pic32/cores/pic32/HardwareSerial.cpp
@@ -582,6 +582,10 @@ USBSerial::USBSerial(ring_buffer	*rx_buffer)
 	_rx_buffer->tail	=	0;
 }
 
+USBSerial::operator int() {
+    return gConnected ? 1 : 0;
+}
+
 #ifdef _DEBUG_USB_VIA_SERIAL0_
 	#define	DebugViaSerial0(x)	Serial0.println(x)
 #else

--- a/hardware/pic32/cores/pic32/HardwareSerial.h
+++ b/hardware/pic32/cores/pic32/HardwareSerial.h
@@ -141,6 +141,7 @@ class USBSerial : public Stream
 		virtual	void	write(uint8_t);
 		virtual void	write(const char *str);
 		virtual void	write(const uint8_t *buffer, size_t size);
+        operator        int();
 
 		using	Print::write; // pull in write(str) and write(buf, size) from Print
 };

--- a/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.c
+++ b/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.c
@@ -164,7 +164,7 @@ static int			gRX_length[NRX];
 static volatile byte			gRX_in;
 static volatile byte			gRX_out;
 
-static boolean      gConnected = false;
+boolean      gConnected = false;
 
 
 //*******************************************************************************

--- a/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.h
+++ b/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.h
@@ -7,6 +7,7 @@
 #define     USB_SERIAL_MIN_BUFFER_FREE      128
 
 extern boolean gCdcacm_active;
+extern boolean gConnected;
 
 typedef void (*cdcacm_reset_cbfn)(void);
 typedef boolean (*cdcacm_storedata_cbfn)(const byte *buffer, int length);


### PR DESCRIPTION
The current CDC driver uses a bit of a fudge to determine if the host has anything connected to it's end of the pipe.  I.e., if the transmit buffers fill up and aren't emptied enough within 1 second it is assumed that the remote end isn't connected and the CDC is set to discard any future outgoing communications.  Once something is received on the CDC connection that discard flag is then cleared and sending is allowed again.  This has a number of drawbacks:
1. Once you start sending data with nothing connected to the remote end and the buffers fill up there is a 1 second delay in your sketch while it times out.
2. All subsequent communication is disabled until a character is sent by the remote end - not always possible or desirable depending on what is at the remote end doing the communicating.

The CDC protocol has a "line state" facility which informs the device whether or not something is connected at the hosts's end (setup packet of SET_CONTROL_LINE_STATE).  Bit 0 of the value field transmitted with that packet indicates the presence of a host side communication program; 0 is not present, 1 is present.

This patch replaces the original method of detecting and timing out the remote connection (boolean gDiscard) and replaces it with a system which monitors this host present flag.  If the host is indicated as present then outgoing communication is allowed.  If it is not indicated as present then communication is disallowed at the earliest possible opportunity.  This has the effect of:
1. Buffers do not fill up with untransmittable data.
2. There is no delay of 1 second while the transmitting routine waits for buffers to clear that will never clear.
3. There is no requirement for the host to send a character to the device to restart communications after a timeout.
