### PR TITLE
upload max was sized too small, sized for USB not FTDI

### DIFF
--- a/hardware/pic32/variants/Cmod/boards.txt
+++ b/hardware/pic32/variants/Cmod/boards.txt
@@ -18,7 +18,7 @@ cmod.compiler.cpp.flags=-O2::-c::-mno-smart-io::-w::-fno-exceptions::-ffunction-
 
 cmod.upload.protocol=stk500v2
 # 128KB - 4K for EEPROM
-cmod.upload.maximum_size=122880
+cmod.upload.maximum_size=126976
 cmod.upload.speed=115200
 
 cmod.bootloader.low_fuses=0xff


### PR DESCRIPTION
The chipKIT Cmod uses and FTDI chip and does not use the USB bootloader. The USB bootloader is a splitflash bootloader using 4K of program flash that the Cmod does not need to use. Boards.txt was copied from the DP32 which uses the USB bootloader and the max upload size for the Cmod was 4K too small leaving room for the non-existent USB code. This updates the max upload size to allow the use of the last 4K of flash.
