### PR TITLE
Enabled virtual program button in Quick240

### DIFF
--- a/hardware/pic32/variants/quicK240/Board_Defs.h
+++ b/hardware/pic32/variants/quicK240/Board_Defs.h
@@ -56,6 +56,10 @@
 
 #define	_BOARD_NAME_	"chipKIT Max32"
 
+#define VIRTUAL_PROGRAM_BUTTON_TRIS TRISGbits.TRISG15
+#define VIRTUAL_PROGRAM_BUTTON LATGbits.LATG15
+#define USE_VIRTUAL_PROGRAM_BUTTON 1
+
 /* Define the Microcontroller peripherals available on the board.
 */
 #define	NUM_DIGITAL_PINS	87


### PR DESCRIPTION
Found that these need to be defined in order for the virtual program button stuff to work.
