### PR TITLE
Removed default serial string

### DIFF
--- a/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.c
+++ b/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.c
@@ -45,7 +45,7 @@
 #endif
 
 #ifndef CDCACM_SER
-#define CDCACM_SER "BURxxx"
+#define CDCACM_SER ""
 #endif
 
 // We have allocated 8 PIDs to you from A660 to A667 (hex).


### PR DESCRIPTION
The serial string BURxxx is, because it's not what the bootloader has, causing Windows to enumerate USB based boards as a different device in bootloader and sketch serial modes.
