### PR TITLE
Fixed chipKIT Pi's broken hardware interrupt pins. 

### DIFF
--- a/hardware/pic32/cores/pic32/pins_arduino.h
+++ b/hardware/pic32/cores/pic32/pins_arduino.h
@@ -182,7 +182,7 @@
 #define	timerOCtoDigitalPin(P) (uint8_t)(output_compare_to_digital_pin_PGM[P])
 #define	timerOCtoOutputSelect(P) (uint16_t)(output_compare_to_pps_sel_PGM[P])
 #define	externalIntToDigitalPin(P) (uint8_t)(external_int_to_digital_pin_PGM[P])
-#define	externalIntToInputSelect(P) (uint8_t)(ext_int_to_pps_sel_PGM[P])
+#define	externalIntToInputSelect(P) (uint16_t)(ext_int_to_pps_sel_PGM[P])
 #else
 // This macro returns a pointer to a p32_ioport structure as defined in p32_defs.h
 // For MX3xx-MX7xx devices, the port register map starts with the TRISx register
@@ -226,7 +226,7 @@
 #if !defined(OPT_BOARD_DATA)
 
 extern const uint16_t output_compare_to_pps_sel_PGM[];
-extern const uint8_t ext_int_to_pps_sel_PGM[];
+extern const uint16_t ext_int_to_pps_sel_PGM[];
 
 #endif
 #endif

--- a/hardware/pic32/variants/ChipKIT_Pi/Board_Data.c
+++ b/hardware/pic32/variants/ChipKIT_Pi/Board_Data.c
@@ -333,9 +333,9 @@ const uint8_t output_compare_to_digital_pin_PGM[] = {
 
 const uint8_t external_int_to_digital_pin_PGM[] = {
 	NOT_PPS_PIN,		// INT0 is not mappable;    RB7
-	PIN_INT1,			// A3, B14, B0, B10, B9;    B9  INT1R = RPB9 = 4
-	PIN_INT2,			// A2, B6, A4, B13, B2;     B2  INT2R = RPB2 = 4
-	PIN_INT3,			// A1, B5, B1, B11, B8;     B8  INT3R = RPB8 = 4
+	PIN_INT1,			// A3, B14, B0, B10, B9;    B10  INT1R = RPB10 = 3
+	PIN_INT2,			// A2, B6, A4, B13, B2;     B13  INT2R = RPB13 = 3
+	PIN_INT3,			// A1, B5, B1, B11, B8;     B5  INT3R = RPB5 = 1
 	PIN_INT4			// A0, B3, B4, B15, B7;     B4  INT4R = RPB4 = 2
 };
 
@@ -471,7 +471,8 @@ int	_board_getPinMode(uint8_t pin, uint8_t * mode) {
 **		control will pass through the normal digitalWrite code. If
 **		it returns a non-zero value the normal digitalWrite code isn't
 **		executed.
-*/#if	(OPT_BOARD_DIGITAL_IO != 0)
+*/
+#if	(OPT_BOARD_DIGITAL_IO != 0)
 
 int	_board_digitalWrite(uint8_t pin, uint8_t val) {
 	

--- a/hardware/pic32/variants/ChipKIT_Pi/Board_Defs.h
+++ b/hardware/pic32/variants/ChipKIT_Pi/Board_Defs.h
@@ -8,7 +8,7 @@
 /************************************************************************/
 /*  File Description:													*/
 /*																		*/
-/* This file contains the board specific declartions and data structure	*/
+/* This file contains the board specific declarations and data structure*/
 /* to customize the chipKIT MPIDE for use with a ChipKIT PI board using */
 /*																		*/
 /* This code is based on earlier work:									*/
@@ -143,11 +143,11 @@ NOTE: The ChipKIT Pi has two user LEDs
 /*					Interrupt Pin Declarations					*/
 /* ------------------------------------------------------------ */
 
-#define	PIN_INT0	 1      // RB7 non-PPS
-#define	PIN_INT1	 3      // B9  INT1R = RPB9 = 4
-#define PIN_INT2	13      // B2  INT2R = RPB2 = 4
-#define	PIN_INT3	 2      // B8  INT3R = RPB8 = 4
-#define	PIN_INT4	17      // B4  INT4R = RPB4 = 2
+#define	PIN_INT0	11      // RB7 non-PPS
+#define	PIN_INT1	 8      // B10 INT1R = RPB10 = 3
+#define PIN_INT2	 3      // B13 INT2R = RPB13 = 3
+#define	PIN_INT3	 2      // B5  INT3R = RPB5 = 1
+#define	PIN_INT4	 1      // B4  INT4R = RPB4 = 2
 
 /* ------------------------------------------------------------ */
 /*					SPI Pin Declarations						*/
@@ -172,9 +172,9 @@ const static uint8_t SCK  = 13;		// RB14 SCK1    CVREF/AN10/C3INB/RPB14/VBUSON/S
 ** used to map an analog pin number to the corresponding digital
 ** pin number.
 */
-#define	A0		14  // RA0		
+#define	A0		14  // RA0
 #define	A1		15  // RB15
-#define	A4		16  // RB2		
+#define	A4		16  // RB2
 #define	A5		17  // RB3
 
 /* ------------------------------------------------------------ */
@@ -208,7 +208,7 @@ const static uint8_t SCK  = 13;		// RB14 SCK1    CVREF/AN10/C3INB/RPB14/VBUSON/S
 /* ------------------------------------------------------------ */
 /* Macros used to access the port and pin mapping tables.
 ** These are mostly generic, but some of them may be board specific.
-** These perform slightly better as macros compared to inline functions
+** These perform slightly better as macros compared to in-line functions
 */
 #undef digitalPinToAnalog
 #define	digitalPinToAnalog(P) ( digital_pin_to_analog_PGM[P] )


### PR DESCRIPTION
We now have working INT0 through INT4 on Arduino pins 10, 8, 3, 2 and 1.  (Note, the change in pins_arduino.h will affect all PPS based PIC32s for hardware interrupts. The rest of them (Fubarino Mini, DP32, etc. should work now too.)
