### PR TITLE
Fix for issue #426 moved avr files out of the compiler

### DIFF
--- a/hardware/pic32/cores/pic32/avr/interrupt.h
+++ b/hardware/pic32/cores/pic32/avr/interrupt.h
@@ -1,0 +1,8 @@
+#ifndef __INTERRUPT_H_
+#define __INTERRUPT_H_ 1
+
+#error ******** This sketch or library uses AVR-specific code that may not work \
+with the chipKIT platform. See this forum for more information on porting code \
+to chipKIT [www.chipkit.org/forum/viewforum.php?f=7] ********
+
+#endif /* __INTERRUPTE_H_ */

--- a/hardware/pic32/cores/pic32/avr/io.h
+++ b/hardware/pic32/cores/pic32/avr/io.h
@@ -1,0 +1,8 @@
+#ifndef __IO_H_
+#define __IO_H_ 1
+
+#error ******** This sketch or library uses AVR-specific code that may not work \
+with the chipKIT platform. See this forum for more information on porting code \
+to chipKIT [www.chipkit.org/forum/viewforum.php?f=7] ********
+
+#endif /* __IOE_H_ */

--- a/hardware/pic32/cores/pic32/avr/pgmspace.h
+++ b/hardware/pic32/cores/pic32/avr/pgmspace.h
@@ -1,0 +1,8 @@
+#ifndef __PGMSPACE_H_
+#define __PGMSPACE_H_ 1
+
+#error ******** This sketch or library uses AVR-specific code that may not work \
+with the chipKIT platform. See this forum for more information on porting code \
+to chipKIT [www.chipkit.org/forum/viewforum.php?f=7] ********
+
+#endif /* __PGMSPACE_H_ */


### PR DESCRIPTION
Added the interrupt.h file. Moved these files to pic32/core/pic32/avr/

Next need to fix them with compatibility code instead of just warning.
