### PR TITLE
Fix for issue #438 : Fixed MX1/2 PWM (OC) outputs (analogWrite()) e.g. o...

### DIFF
--- a/hardware/pic32/cores/pic32/pins_arduino.h
+++ b/hardware/pic32/cores/pic32/pins_arduino.h
@@ -180,12 +180,12 @@
 
 
 #define	timerOCtoDigitalPin(P) (uint8_t)(output_compare_to_digital_pin_PGM[P])
-#define	timerOCtoOutputSelect(P) (uint8_t)(output_compare_to_pps_sel_PGM[P])
+#define	timerOCtoOutputSelect(P) (uint16_t)(output_compare_to_pps_sel_PGM[P])
 #define	externalIntToDigitalPin(P) (uint8_t)(external_int_to_digital_pin_PGM[P])
-#define	externalIntToInputSelect(P) (uint8_t)(ext_int_to_pps_sel_PGM[P])
+#define	externalIntToInputSelect(P) (uint16_t)(ext_int_to_pps_sel_PGM[P])
 #else
 // This macro returns a pointer to a p32_ioport structure as defined in p32_defs.h
-// For MX3xx-MX7xx devices, the port registger map starts with the TRISx register
+// For MX3xx-MX7xx devices, the port register map starts with the TRISx register
 #define portRegisters(P) ((p32_ioport *)(port_to_tris_PGM[P]))
 #endif
 
@@ -225,8 +225,8 @@
 #if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
 #if !defined(OPT_BOARD_DATA)
 
-extern const uint8_t output_compare_to_pps_sel_PGM[];
-extern const uint8_t ext_int_to_pps_sel_PGM[];
+extern const uint16_t output_compare_to_pps_sel_PGM[];
+extern const uint16_t ext_int_to_pps_sel_PGM[];
 
 #endif
 #endif

--- a/hardware/pic32/cores/pic32/wiring_analog.c
+++ b/hardware/pic32/cores/pic32/wiring_analog.c
@@ -240,7 +240,7 @@ void analogWrite(uint8_t pin, int val)
 	}
 
 #if (OPT_BOARD_ANALOG_WRITE != 0)
-	/* Peform any board specific processing.
+	/* Perform any board specific processing.
 	*/
 int	_board_analogWrite(uint8_t pin, int val);
 
@@ -278,7 +278,6 @@ int	_board_analogWrite(uint8_t pin, int val);
 	        digitalWrite(pin, HIGH);
 	    }
 	}
-
 	else
 	{
 		/* It's a PWM capable pin. Timer 2 is used for the time base
@@ -311,7 +310,6 @@ int	_board_analogWrite(uint8_t pin, int val);
 		*/
 		if ((pwm_active & pwm_mask) == 0) 
 		{
-
 #if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
 			volatile uint32_t *	pps;
 				
@@ -331,7 +329,6 @@ int	_board_analogWrite(uint8_t pin, int val);
 		/* Set the duty cycle register for the requested output compare
 		*/
 		ocp->ocxRs.reg = ((PWM_TIMER_PERIOD*val)/256);
-
 	}
 }
 

--- a/hardware/pic32/variants/Cmod/Board_Data.c
+++ b/hardware/pic32/variants/Cmod/Board_Data.c
@@ -439,6 +439,7 @@ const uint8_t analog_pin_to_channel_PGM[] = {
 */
 
 const uint8_t output_compare_to_digital_pin_PGM[] = {
+	NOT_PPS_PIN,// There is no OC0, so this one needs to be blank
 	PIN_OC1,	// RPB4 (RPB4R = 5)	
 	PIN_OC2,	// RPB8 (RPB8R = 5)
 	PIN_OC3,	// RPB9 (RPB9R = 5)

--- a/hardware/pic32/variants/DP32/Board_Data.c
+++ b/hardware/pic32/variants/DP32/Board_Data.c
@@ -315,6 +315,7 @@ const uint8_t analog_pin_to_channel_PGM[] = {
 */
 
 const uint8_t output_compare_to_digital_pin_PGM[] = {
+	NOT_PPS_PIN,		// There is no OC0, so this one needs to be blank
 	PIN_OC1,	        // A0, B3, B4, B15, B7  ; B15   RPB15R  = 5  	
 	PIN_OC2,	        // A1, B5, B1, B11, B8  ; B8    RPB8R   = 5
 	PIN_OC3,	        // A3, B14, B0, B10, B9 ; B9    RPB9R   = 5

--- a/hardware/pic32/variants/Fubarino_Mini/Board_Data.c
+++ b/hardware/pic32/variants/Fubarino_Mini/Board_Data.c
@@ -8,7 +8,7 @@
 /************************************************************************/
 /*  File Description:													*/
 /*																		*/
-/* This file contains the board specific declartions and data structure	*/
+/* This file contains the board specific declarations and data structure*/
 /* to customize the chipKIT MPIDE for use with a generic board using a	*/
 /* PIC32 part in a 64-pin package.										*/
 /*																		*/
@@ -194,16 +194,16 @@ const uint16_t	digital_pin_to_bit_mask_PGM[] = {
 ** input associated with that pin.
 */
 const uint16_t	digital_pin_to_timer_PGM[] = {
-	NOT_ON_TIMER ,	//  0  RB13
+	_TIMER_OC5 ,	//  0  RB13
 	NOT_ON_TIMER ,	//  1  RA10
 	NOT_ON_TIMER ,	//  2  RA7
 	NOT_ON_TIMER ,	//  3  RB14
-	NOT_ON_TIMER ,	//  4  RB15
+	_TIMER_OC1 ,	//  4  RB15
 	NOT_ON_TIMER ,	//  5  RA0
 	NOT_ON_TIMER ,	//  6  RA1
-	NOT_ON_TIMER ,	//  7  RB0
-	NOT_ON_TIMER ,	//  8  RB1
-	NOT_ON_TIMER ,	//  9  RB2
+	_TIMER_OC3 ,	//  7  RB0
+	_TIMER_OC2 ,	//  8  RB1
+	_TIMER_OC4 ,	//  9  RB2
 	NOT_ON_TIMER ,  // 10  RB3
 	NOT_ON_TIMER ,	// 11  RC0
 	NOT_ON_TIMER ,	// 12  RC1
@@ -232,14 +232,14 @@ const uint16_t	digital_pin_to_timer_PGM[] = {
 /* ------------------------------------------------------------ */
 /* This table maps from a digital pin number to the corresponding
 ** PPS register. This register is used to select the peripheral output
-** connected to the pin. The register is set to 0 to disconnedt the
+** connected to the pin. The register is set to 0 to disconnect the
 ** pin from any peripheral so it can be used as GPIO.
 ** For PIC32MX1xx/2xx series devices, the PPS output select registers
 ** are arranged as a contiguous series of 32 bit registers. This table
 ** treats these registers as an array of DWORDs an stores the index
 ** to the register.
 */
-const uint16_t digital_pin_to_pps_out_PGM[] = {
+const uint8_t digital_pin_to_pps_out_PGM[] = {
 	_PPS_OUT(_PPS_RPB13R),	//	0	RB13
 	NOT_PPS_PIN,	        //	1	RA10
 	NOT_PPS_PIN,	        //	2	RA7
@@ -401,14 +401,13 @@ const uint8_t analog_pin_to_channel_PGM[] = {
 ** devices.
 */
 
-/// TODO: UPdate
 const uint8_t output_compare_to_digital_pin_PGM[] = {
-	NOT_PPS_PIN,		// not used
-	9,					// OC1, JB-02
-	25,					// OC2, JD-02
-	19,					// OC3, JC-04
-	13,					// OC4, JB-08
-	27					// OC5, JD-04
+	NOT_PPS_PIN,				// There is no OC0, so this one needs to be blank
+	PIN_OC1,					// A0, B3, B4, B15, B7  ; B15   RPB15R  = 5
+	PIN_OC2,					// A1, B5, B1, B11, B8  ; B1    RPB1R   = 5
+	PIN_OC3,					// A3, B14, B0, B10, B9 ; B0    RPB0R   = 5
+	PIN_OC4,					// A2, B6, A4, B13, B2  ; B2    RPB2R   = 5
+	PIN_OC5						// A2, B6, A4, B13, B2	; B13   RPB13R  = 6
 };
 
 /* ------------------------------------------------------------ */

--- a/hardware/pic32/variants/Fubarino_Mini/Board_Defs.h
+++ b/hardware/pic32/variants/Fubarino_Mini/Board_Defs.h
@@ -8,7 +8,7 @@
 /************************************************************************/
 /*  File Description:													*/
 /*																		*/
-/* This file contains the board specific declartions and data structure	*/
+/* This file contains the board specific declarations and data structure*/
 /* to customize the chipKIT MPIDE for use with a generic board using a	*/
 /* PIC32 part in a 64-pin package.										*/
 /*																		*/
@@ -51,7 +51,7 @@
 /*				Public Board Declarations						*/
 /* ------------------------------------------------------------ */
 /* The following define symbols that can be used in a sketch to
-** refer to periperhals on the board generically.
+** refer to peripherals on the board generically.
 */
 
 #define	_BOARD_NAME_	"Fubarino Mini"
@@ -118,10 +118,10 @@
 /* ------------------------------------------------------------ */
 
 #define PIN_OC1		4
-#define	PIN_OC2		7
-#define	PIN_OC3		8
+#define	PIN_OC3		7
+#define	PIN_OC2		8
 #define	PIN_OC4		9
-#define	PIN_OC5		10
+#define	PIN_OC5		0
 
 #define PIN_IC1		0
 #define PIN_IC2		1


### PR DESCRIPTION
...n Fubarino Mini

Some functions/macros were typecast as uint8_t rather than uint16_t in pins_arduino.h which messed up PPS mapping for PMW outputs.
Also fixed a small bug on OC mapping for Cmod and DP32.
