### PR TITLE
Fix for #440 - Wire examples use invalid I2C addresses (due to PIC32 har...

### DIFF
--- a/hardware/pic32/libraries/Wire/examples/master_reader/master_reader.pde
+++ b/hardware/pic32/libraries/Wire/examples/master_reader/master_reader.pde
@@ -20,7 +20,7 @@ void setup()
 
 void loop()
 {
-  Wire.requestFrom(2, 6);    // request 6 bytes from slave device #2
+  Wire.requestFrom(20, 6);    // request 6 bytes from slave device #20
 
   while(Wire.available())    // slave may send less than requested
   { 

--- a/hardware/pic32/libraries/Wire/examples/master_writer/master_writer.pde
+++ b/hardware/pic32/libraries/Wire/examples/master_writer/master_writer.pde
@@ -21,7 +21,7 @@ byte x = 0;
 
 void loop()
 {
-  Wire.beginTransmission(4); // transmit to device #4
+  Wire.beginTransmission(40); // transmit to device #40
   Wire.send("x is ");        // sends five bytes
   Wire.send(x);              // sends one byte  
   Wire.endTransmission();    // stop transmitting

--- a/hardware/pic32/libraries/Wire/examples/slave_receiver/slave_receiver.pde
+++ b/hardware/pic32/libraries/Wire/examples/slave_receiver/slave_receiver.pde
@@ -14,7 +14,7 @@
 
 void setup()
 {
-  Wire.begin(4);                // join i2c bus with address #4
+  Wire.begin(40);                // join i2c bus with address #40
   Wire.onReceive(receiveEvent); // register event
   Serial.begin(9600);           // start serial for output
 }

--- a/hardware/pic32/libraries/Wire/examples/slave_sender/slave_sender.pde
+++ b/hardware/pic32/libraries/Wire/examples/slave_sender/slave_sender.pde
@@ -14,7 +14,7 @@
 
 void setup()
 {
-  Wire.begin(2);                // join i2c bus with address #2
+  Wire.begin(20);               // join i2c bus with address #20
   Wire.onRequest(requestEvent); // register event
 }
 


### PR DESCRIPTION
...dware bug)

I pushed all of the addresses (TX and RX) in the examples above 0x08.
