### PR TITLE
add plib to the linker scripts

### DIFF
--- a/hardware/pic32/cores/pic32/chipKIT-application-32MX120F032.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-32MX120F032.ld
@@ -19,6 +19,7 @@ PROVIDE(_min_heap_size = 0x800) ;
  * Processor-specific object file.  Contains SFR definitions.
  *************************************************************************/
 INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_32MX120F032D.a") 
 
 /*************************************************************************
  * Memory Regions

--- a/hardware/pic32/cores/pic32/chipKIT-application-32MX250F128.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-32MX250F128.ld
@@ -19,6 +19,7 @@ PROVIDE(_min_heap_size = 0x800) ;
  * Processor-specific object file.  Contains SFR definitions.
  *************************************************************************/
 INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_32MX250F128D.a") 
 
 /*************************************************************************
  * Memory Regions

--- a/hardware/pic32/cores/pic32/chipKIT-application-32MX320F128.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-32MX320F128.ld
@@ -19,6 +19,7 @@ PROVIDE(_min_heap_size = 0x800) ;
  * Processor-specific object file.  Contains SFR definitions.
  *************************************************************************/
 INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_32MX320F128H.a") 
 
 /*************************************************************************
  * Memory Regions

--- a/hardware/pic32/cores/pic32/chipKIT-application-32MX340F512.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-32MX340F512.ld
@@ -19,6 +19,7 @@ PROVIDE(_min_heap_size = 0x800) ;
  * Processor-specific object file.  Contains SFR definitions.
  *************************************************************************/
 INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_32MX340F512H.a") 
 
 /*************************************************************************
  * Memory Regions

--- a/hardware/pic32/cores/pic32/chipKIT-application-32MX360F512.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-32MX360F512.ld
@@ -19,6 +19,7 @@ PROVIDE(_min_heap_size = 0x800) ;
  * Processor-specific object file.  Contains SFR definitions.
  *************************************************************************/
 INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_32MX360F512L.a") 
 
 /*************************************************************************
  * Memory Regions

--- a/hardware/pic32/cores/pic32/chipKIT-application-32MX440F128.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-32MX440F128.ld
@@ -19,6 +19,7 @@ PROVIDE(_min_heap_size = 0x800) ;
  * Processor-specific object file.  Contains SFR definitions.
  *************************************************************************/
 INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_32MX440F128H.a") 
 
 /*************************************************************************
  * Memory Regions

--- a/hardware/pic32/cores/pic32/chipKIT-application-32MX440F256.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-32MX440F256.ld
@@ -19,6 +19,7 @@ PROVIDE(_min_heap_size = 0x800) ;
  * Processor-specific object file.  Contains SFR definitions.
  *************************************************************************/
 INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_32MX440F256H.a") 
 
 /*************************************************************************
  * Memory Regions

--- a/hardware/pic32/cores/pic32/chipKIT-application-32MX440F512.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-32MX440F512.ld
@@ -19,6 +19,7 @@ PROVIDE(_min_heap_size = 0x800) ;
  * Processor-specific object file.  Contains SFR definitions.
  *************************************************************************/
 INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_32MX440F512H.a") 
 
 /*************************************************************************
  * Memory Regions

--- a/hardware/pic32/cores/pic32/chipKIT-application-32MX460F512.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-32MX460F512.ld
@@ -19,6 +19,7 @@ PROVIDE(_min_heap_size = 0x800) ;
  * Processor-specific object file.  Contains SFR definitions.
  *************************************************************************/
 INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_32MX460F512L.a") 
 
 /*************************************************************************
  * Memory Regions

--- a/hardware/pic32/cores/pic32/chipKIT-application-32MX795F512.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-32MX795F512.ld
@@ -19,6 +19,7 @@ PROVIDE(_min_heap_size = 0x800) ;
  * Processor-specific object file.  Contains SFR definitions.
  *************************************************************************/
 INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_32MX795F512L.a")
 
 /*************************************************************************
  * Memory Regions

--- a/hardware/pic32/cores/pic32/chipKIT-application-COMMON.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-COMMON.ld
@@ -35,13 +35,10 @@
  * For interrupt vector handling
  *************************************************************************/
 PROVIDE(_vector_spacing = 0x00000001);
-
 INPUT("crtbegin.o")
-
 INPUT("crtend.o")
-
 INPUT("crtn.o")
-
+OPTIONAL("libmchp_peripheral.a") 
 
 /*************************************************************************
  * Start the layout of memory, the sections...

--- a/hardware/pic32/libraries/EEPROM/utility/Deeprom.c
+++ b/hardware/pic32/libraries/EEPROM/utility/Deeprom.c
@@ -54,7 +54,7 @@
 /* ------------------------------------------------------------ */
 
 //Aligns the flash memory used for EEPROM emulation in the linker script
-__attribute__ ((aligned(_EEPROM_PAGE_SIZE*4),section(".eeprom_pic32")))
+__attribute__ ((space(code),aligned(_EEPROM_PAGE_SIZE*4),section(".eeprom_pic32")))
 unsigned int eedata_addr[_EEPROM_PAGE_COUNT][_EEPROM_PAGE_SIZE];
 
 // Default max EEPROM address sketch can use. Note: can be adjusted by sketch.

--- a/hardware/pic32/variants/Cmod/chipKIT-application-32MX150F128.ld
+++ b/hardware/pic32/variants/Cmod/chipKIT-application-32MX150F128.ld
@@ -19,6 +19,7 @@ PROVIDE(_min_heap_size = 0x800) ;
  * Processor-specific object file.  Contains SFR definitions.
  *************************************************************************/
 INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_PIC32MX150F128D.a") 
 
 /*************************************************************************
  * Memory Regions

--- a/hardware/pic32/variants/WF32/chipKIT-application-32MX695F512.ld
+++ b/hardware/pic32/variants/WF32/chipKIT-application-32MX695F512.ld
@@ -19,6 +19,7 @@ PROVIDE(_min_heap_size = 0x800) ;
  * Processor-specific object file.  Contains SFR definitions.
  *************************************************************************/
 INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_32MX695F512L.a") 
 
 /*************************************************************************
  * Memory Regions

--- a/hardware/pic32/variants/WiFire/MZ-application-32MZ2048ECX.ld
+++ b/hardware/pic32/variants/WiFire/MZ-application-32MZ2048ECX.ld
@@ -73,8 +73,8 @@ MEMORY
 {
   kseg0_vector_mem            : ORIGIN = 0x9D000000, LENGTH = 0x1000
   kseg1_vector_mem            : ORIGIN = 0xBD000000, LENGTH = 0x1000
-  kseg0_program_mem    (rx)   : ORIGIN = 0x9D001000, LENGTH = 0x1FEE00
-  kseg0_eeprom_mem            : ORIGIN = 0x9D1FF000, LENGTH = 0x1000
+  kseg0_program_mem    (rx)   : ORIGIN = 0x9D001000, LENGTH = 0x1FB000
+  kseg0_eeprom_mem            : ORIGIN = 0x9D1FC000, LENGTH = 0x4000
   kseg0_boot_mem              : ORIGIN = 0x9FC004B0, LENGTH = 0x0
   kseg1_boot_mem              : ORIGIN = 0xBFC00000, LENGTH = 0x0
   kseg1_boot_mem_4B0          : ORIGIN = 0xBFC004B0, LENGTH = 0x0


### PR DESCRIPTION
allow MX processor to use plib and maintain backwards compatibility for MX parts in the MZ build. MZ processors do not allow plib usage. Also added the space(code) attribute to the eeprom library so the startup code would not try to init the eeprom flash... however this does not fix the problem as it should... Jason will need to investigate further.
