### PR TITLE
Fix for issue #466 and #467 (they're duplicates). We were not clearing t...

### DIFF
--- a/hardware/pic32/cores/pic32/System_Defs.h
+++ b/hardware/pic32/cores/pic32/System_Defs.h
@@ -528,8 +528,8 @@
 
 /* USB Interrupt
 */
-#define	_USB_IPL_ISR	ipl2
-#define	_USB_IPL_IPC	2
+#define	_USB_IPL_ISR	ipl6
+#define	_USB_IPL_IPC	6
 #define	_USB_SPL_IPC	0
 
 /* CAN Interrupts


### PR DESCRIPTION
...he USB interrupt flag before enabling the interrupt.

Also added LENGTHOF macro, and tried compiling with asserts turned on (SODEBUG) and something dies. Still need to debug that. But this code change now allows USB serial to work again.
