### PR TITLE
Added Arduino.h stub link file

### DIFF
--- a/hardware/pic32/cores/pic32/Arduino.h
+++ b/hardware/pic32/cores/pic32/Arduino.h
@@ -1,0 +1,6 @@
+#ifndef _ARDUINO_H
+#define _ARDUINO_H
+
+#include <WProgram.h>
+
+#endif


### PR DESCRIPTION
This will allow basic Arduino 1.0.x libraries to compile without modification (i.e., no need to change Arduino.h to WProgram.h).
