### PR TITLE
Add ability to specify PPS mappings in DSPI begin function

### DIFF
--- a/hardware/pic32/libraries/DSPI/DSPI.cpp
+++ b/hardware/pic32/libraries/DSPI/DSPI.cpp
@@ -174,6 +174,56 @@ DSPI::init(uint8_t irqErr, uint8_t irqRx, uint8_t irqTx, isrFunc isrHandler) {
     isr = isrHandler;
 }
 
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
+
+/* ------------------------------------------------------------ */
+/***	DSPI::begin
+**
+**	Parameters:
+**		uint8_t miso - MISO pin PPS mapping
+**      uint8_t mosi - MOSI pin PPS mapping
+**
+**	Return Value:
+**		none
+**
+**	Errors:
+**		none
+**
+**	Description:
+**		Initialize the SPI port with new PPS mappings.
+*/
+
+void DSPI::begin(uint8_t miso, uint8_t mosi) {
+    pinMISO = miso;
+    pinMOSI = mosi;
+    begin(pinSS);
+}
+
+/* ------------------------------------------------------------ */
+/***	DSPI::begin
+**
+**	Parameters:
+**		uint8_t miso - MISO pin PPS mapping
+**      uint8_t mosi - MOSI pin PPS mapping
+**      uint8_t ss   - Slace Select pin
+**
+**	Return Value:
+**		none
+**
+**	Errors:
+**		none
+**
+**	Description:
+**		Initialize the SPI port with new PPS mappings.
+*/
+void DSPI::begin(uint8_t miso, uint8_t mosi, uint8_t ss) {
+    pinMISO = miso;
+    pinMOSI = mosi;
+    pinSS = ss;
+    begin(pinSS);
+}
+#endif
+
 /* ------------------------------------------------------------ */
 /***	DSPI::begin
 **

--- a/hardware/pic32/libraries/DSPI/DSPI.h
+++ b/hardware/pic32/libraries/DSPI/DSPI.h
@@ -132,6 +132,10 @@ public:
 */
 void		begin();
 void		begin(uint8_t pin);
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
+void        begin(uint8_t miso, uint8_t mosi);
+void        begin(uint8_t miso, uint8_t mosi, uint8_t pin);
+#endif
 void		end();
 void		setSpeed(uint32_t spd);
 void		setMode(uint16_t  mod);


### PR DESCRIPTION
This change allows you to specify new pin mappings for MISO and MOSI in the begin() function of the DSPI class.  This means you're not faffing around with mapPps etc, which for some unknown reason (as yet) causes the UECIDE SD library to break.
