### PR TITLE
Added basic MX470 support

### DIFF
--- a/hardware/pic32/cores/pic32/HardwareSerial.cpp
+++ b/hardware/pic32/cores/pic32/HardwareSerial.cpp
@@ -127,7 +127,7 @@ void __attribute__((interrupt(),nomips16)) IntSer7Handler(void);
 **		any global variables used by the object.
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 HardwareSerial::HardwareSerial(p32_uart * uartT, int irqT, int vecT, int iplT, int splT, isrFunc isrHandler, int pinT, int pinR, ppsFunctionType ppsT, ppsFunctionType ppsR)
 #else
 HardwareSerial::HardwareSerial(p32_uart * uartT, int irqT, int vecT, int iplT, int splT, isrFunc isrHandler)
@@ -142,7 +142,7 @@ HardwareSerial::HardwareSerial(p32_uart * uartT, int irqT, int vecT, int iplT, i
 	spl  = (uint8_t)splT;
     isr  = isrHandler;
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 	pinTx = (uint8_t)pinT;
 	pinRx = (uint8_t)pinR;
 	ppsTx = ppsT;
@@ -194,7 +194,7 @@ void HardwareSerial::begin(unsigned long baudRate)
 	*/
 	purge();
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 	/* Map the UART TX to the appropriate pin.
 	*/
     mapPps(pinTx, ppsTx);
@@ -997,7 +997,7 @@ void __attribute__((interrupt(), nomips16)) IntSer7Handler(void)
 */
 USBSerial		Serial(&rx_bufferUSB);
 #if defined(_SER0_BASE)
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 HardwareSerial Serial0((p32_uart *)_SER0_BASE, _SER0_IRQ, _SER0_VECTOR, _SER0_IPL, _SER0_SPL, IntSer0Handler, _SER0_TX_PIN, _SER0_RX_PIN, _SER0_TX_OUT, _SER0_RX_IN);
 #else
 HardwareSerial Serial0((p32_uart *)_SER0_BASE, _SER0_IRQ, _SER0_VECTOR, _SER0_IPL, _SER0_SPL, IntSer0Handler);
@@ -1012,7 +1012,7 @@ HardwareSerial Serial0((p32_uart *)_SER0_BASE, _SER0_IRQ, _SER0_VECTOR, _SER0_IP
 ** however MZ have 6
 */
 #if defined(_SER0_BASE)
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 HardwareSerial Serial((p32_uart *)_SER0_BASE, _SER0_IRQ, _SER0_VECTOR, _SER0_IPL, _SER0_SPL, IntSer0Handler, _SER0_TX_PIN, _SER0_RX_PIN, _SER0_TX_OUT, _SER0_RX_IN);
 #else
 HardwareSerial Serial((p32_uart *)_SER0_BASE, _SER0_IRQ, _SER0_VECTOR, _SER0_IPL, _SER0_SPL, IntSer0Handler);
@@ -1022,7 +1022,7 @@ HardwareSerial Serial((p32_uart *)_SER0_BASE, _SER0_IRQ, _SER0_VECTOR, _SER0_IPL
 #endif	//defined(_USB) && defined(_USE_USB_FOR_SERIAL_)
 
 #if defined(_SER1_BASE)
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 HardwareSerial Serial1((p32_uart *)_SER1_BASE, _SER1_IRQ, _SER1_VECTOR, _SER1_IPL, _SER1_SPL, IntSer1Handler, _SER1_TX_PIN, _SER1_RX_PIN, _SER1_TX_OUT, _SER1_RX_IN);
 #else
 HardwareSerial Serial1((p32_uart *)_SER1_BASE, _SER1_IRQ, _SER1_VECTOR, _SER1_IPL, _SER1_SPL, IntSer1Handler);

--- a/hardware/pic32/cores/pic32/HardwareSerial.h
+++ b/hardware/pic32/cores/pic32/HardwareSerial.h
@@ -89,7 +89,7 @@ class HardwareSerial : public Stream
 		uint8_t			vec;		//interrupt vector for the UART
 		uint8_t			ipl;		//interrupt priority level
 		uint8_t			spl;		//interrupt sub-priority level
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 		uint8_t			pinTx;		//digital pin number of TX
 		uint8_t			pinRx;		//digital pin number for RX
 		ppsFunctionType	ppsTx;		//PPS select for UART TX
@@ -103,7 +103,7 @@ class HardwareSerial : public Stream
 		ring_buffer		rx_buffer;	//queue used for UART rx data
 
 	public:
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 		HardwareSerial(p32_uart * uartP, int irq, int vec, int ipl, int spl, isrFunc isrHandler, int pinT, int pinR, ppsFunctionType ppsT, ppsFunctionType ppsR);
 #else
 		HardwareSerial(p32_uart * uartP, int irq, int vec, int ipl, int spl, isrFunc isrHandler);

--- a/hardware/pic32/cores/pic32/HardwareSerial_usb.c
+++ b/hardware/pic32/cores/pic32/HardwareSerial_usb.c
@@ -774,7 +774,7 @@ void	usb_initialize(void)
 
 	// enable int
 #ifdef _USE_USB_IRQ_
-#if defined(__PIC32MX2XX__)
+#if defined(__PIC32MX2XX__) || defined(__PIC32MX47X__)
     IPC7bits.USBIS = 0;
     IPC7bits.USBIP = _USB_IPL_IPC;
 	IFS1bits.USBIF = 0;

--- a/hardware/pic32/cores/pic32/System_Defs.h
+++ b/hardware/pic32/cores/pic32/System_Defs.h
@@ -84,6 +84,12 @@
 	#define NUM_EXTERNAL_INTERRUPTS	5
 #endif
 
+#if defined(__PIC32MX47X__)
+    #define NUM_INT_VECTOR 45
+    #define NUM_INT_REQUEST 75
+    #define NUM_EXTERNAL_INTERRUPTS 5
+#endif
+
 #if defined(__PIC32MX5XX__)
 	#define	NUM_INT_VECTOR	52
 	#define	NUM_INT_REQUEST	76
@@ -376,7 +382,7 @@
 #define	_SPI1_IPL_IPC	3		//interrupt priority for the IPC register
 #define	_SPI1_SPL_IPC	0		//interrupt subpriority for the IPC register
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MX3XX__) || defined(__PIC32MX4XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MX3XX__) || defined(__PIC32MX4XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 #define	_SPI2_IPL_ISR	ipl3    //interrupt priority for the ISR
 #define	_SPI2_IPL_IPC	3       //interrupt priority for the IPC register
 #define	_SPI2_SPL_IPC	0       //interrupt subpriority for the IPC register

--- a/hardware/pic32/cores/pic32/WInterrupts.c
+++ b/hardware/pic32/cores/pic32/WInterrupts.c
@@ -71,7 +71,7 @@ void attachInterrupt(uint8_t interruptNum, void (*userFunc)(void), int mode)
     {
         intFunc[interruptNum]	=	userFunc;
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
         /* For devices with peripheral pin select (PPS), it is necessary to
         ** map the input function to the pin. This is done by loading the
         ** PPS input select register for the specific interrupt with the value

--- a/hardware/pic32/cores/pic32/chipKIT-application-32MX470F512-nobootloader.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-32MX470F512-nobootloader.ld
@@ -1,0 +1,171 @@
+/* Default linker script, for normal executables */
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
+ENTRY(_reset)
+/*
+ * Provide for a minimum stack and heap size
+ * - _min_stack_size -/* Default linker script, for normal executables */
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
+ENTRY(_reset)
+/*
+ * Provide for a minimum stack and heap size
+ * - _min_stack_size - represents the minimum space that must be made
+ *                     available for the stack.  Can be overridden from
+ *                     the command line using the linker's --defsym option.
+ * - _min_heap_size  - represents the minimum space that must be made
+ *                     available for the heap.  Can be overridden from
+ *                     the command line using the linker's --defsym option.
+ */
+EXTERN (_min_stack_size _min_heap_size)
+PROVIDE(_min_stack_size = 0x800) ;
+PROVIDE(_min_heap_size = 0x800) ;
+
+/*************************************************************************
+ * Processor-specific object file.  Contains SFR definitions.
+ *************************************************************************/
+INPUT("processor.o")
+
+/*************************************************************************
+ * Memory Regions
+ *
+ * Memory regions without attributes cannot be used for orphaned sections.
+ * Only sections specifically assigned to these regions can be allocated
+ * into these regions.
+ *************************************************************************/
+MEMORY
+{
+  exception_mem              : ORIGIN = 0x9D000000, LENGTH = 0x1000
+  kseg0_program_mem    (rx)  : ORIGIN = 0x9D001000, LENGTH = 0x7E000
+  kseg0_eeprom_mem           : ORIGIN = 0x9D07F000, LENGTH = 0x1000
+  kseg0_boot_mem             : ORIGIN = 0x9FC00490, LENGTH = 0x970
+  kseg1_boot_mem             : ORIGIN = 0xBFC00000, LENGTH = 0x490
+  debug_exec_mem             : ORIGIN = 0xBFC02000, LENGTH = 0xFF0 
+  config3                    : ORIGIN = 0xBFC02FF0, LENGTH = 4 
+  config2                    : ORIGIN = 0xBFC02FF4, LENGTH = 4
+  config1                    : ORIGIN = 0xBFC02FF8, LENGTH = 4
+  config0                    : ORIGIN = 0xBFC02FFC, LENGTH = 4
+  kseg1_data_mem       (w!x) : ORIGIN = 0xA0000000, LENGTH = 0x20000
+  sfrs                       : ORIGIN = 0xBF800000, LENGTH = 0x100000
+  configsfrs                 : ORIGIN = 0xBFC02FF0, LENGTH = 0x10
+}
+
+/*************************************************************************
+ * Memory Address Equates
+ *************************************************************************/
+_ebase_address  	    = ORIGIN(exception_mem);
+_IMAGE_PTR_TABLE       	= _ebase_address + 0x0F8;
+_IMAGE_HEADER_ADDR      = _ebase_address + 0x0FC;
+_GEN_EXCPT_ADDR         = _ebase_address + 0x180;
+_RESET_ADDR             = ORIGIN(kseg1_boot_mem);
+_EEPROM_ADDR            = ORIGIN(kseg0_eeprom_mem);
+_BEV_EXCPT_ADDR         = 0xBFC00380;
+_DBG_EXCPT_ADDR         = 0xBFC00480;
+_DBG_CODE_ADDR          = ORIGIN(debug_exec_mem);
+
+/*************************************************************************
+ *  Bootloader program directives.
+ *  
+ * _IMAGE_TYPE
+ *
+ *  image type:
+ */
+     
+_imageReserved                      = 0x00000000 ;
+_imageMPIDE                         = 0x00000001 ;  /* This is a normal MPIDE sketch                                                                                                    */
+_imageBootFlashBootloader           = 0x00000002 ;  /* This is a boot flash bootloader                                                                                                  */
+_imageProgramFlashBootloader        = 0x00000004 ;  /* This is a program flash bootloader                                                                                               */
+_imageSplitFlashBootloader          = 0x00000008 ;  /* This has bootloader code in both boot and program flash                                                                          */
+
+ /*
+ *  Instructions for the bootloader
+ */
+                                                                       
+_imageFullFlashEraseLess4KEEProm    = 0x00010000 ;  /* The original bootloader method of erasing all of program flash except the last 4K reserved for eeprom                            */
+_imageJustInTimeFlashErase          = 0x00020000 ;  /* Only flash pages written too needed by the sketch is erased                                                                      */
+_imageLinkerSpecifiedFlashErase     = 0x00040000 ;  /* The linker defines the flash range to erase                                                                                      */
+_imageFullFlashErase                = 0x00080000 ;  /* All of flash is erased                                                                                                           */
+_imageExecutionJumpAddress          = 0x01000000 ;  /* the bootloader will jump to the execution jump address immediately after programming                                             */
+_imageExecutionJumpToFirstInFlash   = 0x02000000 ;  /* the bootloader will jump to the first sketch loaded in flash ignoring the execution jump address immediately after programming   */
+ 
+/*  
+ * _IMAGE_FLASH_SIZE 
+ *
+ *      Typically _imageJustInTimeFlashErase is selected to just erase the pages
+ *      of flash that code is written too; thus leaving all other flash pages untouched.
+ *  
+ *      If _imageLinkerSpecifiedFlashErase set, then the range
+ *      starting from _ebase_address for _IMAGE_FLASH_SIZE bytes are erased.
+ *
+ *      If _imageFullFlashErase is specified, than the whole flash
+ *      as known by the bootloader will be erased. This will erase eeprom as well
+ *
+ *      if _imageFullFlashEraseLess4KEEProm is set, all of flash less the last 4K is
+ *      erased, this is the old default. This bit could be set to make a program flash bootloader
+ *      erasing everything but the old flash. If NOTHING is set, this will be the default as this is the old behavior.
+ *  
+ *  _JUMP_ADDR
+ *  
+ *      This is the address that the bootloader will jump to start execution
+ *      of the sketch. This is almost always _RESET_ADDR.
+ *
+ *      However, you can specify an alternate entry execution point for example
+ *      if you have alternate starup code that, say, shared
+ *      the runtime with other sketches or needed some kind of specific handling
+ *
+ *      Immediately after programming (avrdude upload) the bootloader will typically
+ *      jump to the just loaded sketch, no matter where it was loaded in flash.
+ *      _imageExecutionJumpToFirstInFlash will tell the bootloader to jump to the first
+ *      sketch in flash even if the just loaded one is not at the beginning of flash.
+ *      This is useful when programming sketches in slots of flash and then always
+ *      jumping to the program-flash loader (vector sketch) as if the board was just reset.
+ *      This bit does not effect jumping to a sketch already in flash after reset.
+ *      As of today, after reset, the first program in flash will always be jumped to.
+ *
+ *************************************************************************/
+ _IMAGE_TYPE            = _imageMPIDE | _imageJustInTimeFlashErase | _imageExecutionJumpAddress;
+ _IMAGE_FLASH_SIZE      = LENGTH(exception_mem) + LENGTH(kseg0_program_mem);
+_JUMP_ADDR              = _RESET_ADDR;
+
+SECTIONS
+{
+  .config_BFC02FF0 : {
+    LONG(0x3AFFFFFF)
+  } > config3
+  .config_BFC02FF4 : {
+    LONG(0xFFF879D9)
+  } > config2
+  .config_BFC02FF8 : {
+    LONG(0xFF6ACD5B)
+  } > config1
+  .config_BFC02FFC : {
+    LONG(0x7FFFFFF7)
+  } > config0
+}
+
+SECTIONS
+{
+  .bev_excpt _BEV_EXCPT_ADDR :
+  {
+    KEEP(*(.bev_handler))
+  } > kseg1_boot_mem
+
+  .dbg_excpt _DBG_EXCPT_ADDR (NOLOAD) :
+  {
+    . += (DEFINED (_DEBUGGER) ? 0x8 : 0x0);
+  } > kseg1_boot_mem
+
+  .dbg_code _DBG_CODE_ADDR (NOLOAD) :
+  {
+    . += (DEFINED (_DEBUGGER) ? LENGTH(debug_exec_mem) : 0x0);
+  } > debug_exec_mem
+
+  /* Boot Sections */
+  .reset _RESET_ADDR :
+  {
+    KEEP(*(.reset))
+  } > kseg1_boot_mem
+}
+
+/* From here out every linker script is the same, so just include it */
+/*INCLUDE "chipKIT-application-COMMON.ld"*/

--- a/hardware/pic32/cores/pic32/chipKIT-application-32MX470F512.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-32MX470F512.ld
@@ -1,0 +1,136 @@
+/* Default linker script, for normal executables */
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
+ENTRY(_reset)
+/*
+ * Provide for a minimum stack and heap size
+ * - _min_stack_size - represents the minimum space that must be made
+ *                     available for the stack.  Can be overridden from
+ *                     the command line using the linker's --defsym option.
+ * - _min_heap_size  - represents the minimum space that must be made
+ *                     available for the heap.  Can be overridden from
+ *                     the command line using the linker's --defsym option.
+ */
+EXTERN (_min_stack_size _min_heap_size)
+PROVIDE(_min_stack_size = 0x800) ;
+PROVIDE(_min_heap_size = 0x800) ;
+
+/*************************************************************************
+ * Processor-specific object file.  Contains SFR definitions.
+ *************************************************************************/
+INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_32MX470F512L.a")
+
+/*************************************************************************
+ * Memory Regions
+ *
+ * Memory regions without attributes cannot be used for orphaned sections.
+ * Only sections specifically assigned to these regions can be allocated
+ * into these regions.
+ *************************************************************************/
+MEMORY
+{
+  exception_mem              : ORIGIN = 0x9D000000, LENGTH = 0x1000
+  kseg0_program_mem    (rx)  : ORIGIN = 0x9D001000, LENGTH = 0x7E000
+  kseg0_eeprom_mem           : ORIGIN = 0x9D07F000, LENGTH = 0x1000
+  kseg0_boot_mem             : ORIGIN = 0x9FC00490, LENGTH = 0
+  kseg1_boot_mem             : ORIGIN = 0xBFC00000, LENGTH = 0 
+  debug_exec_mem             : ORIGIN = 0xBFC02000, LENGTH = 0
+  config3                    : ORIGIN = 0xBFC02FF0, LENGTH = 4 
+  config2                    : ORIGIN = 0xBFC02FF4, LENGTH = 4
+  config1                    : ORIGIN = 0xBFC02FF8, LENGTH = 4
+  config0                    : ORIGIN = 0xBFC02FFC, LENGTH = 4
+  kseg1_data_mem       (w!x) : ORIGIN = 0xA0000000, LENGTH = 0x20000
+  sfrs                       : ORIGIN = 0xBF800000, LENGTH = 0x100000
+  configsfrs                 : ORIGIN = 0xBFC02FF0, LENGTH = 0x10
+}
+
+/*************************************************************************
+ * Memory Address Equates
+ *************************************************************************/
+_ebase_address  	    = ORIGIN(exception_mem);
+_IMAGE_PTR_TABLE       	= _ebase_address + 0x0F8;
+_IMAGE_HEADER_ADDR      = _ebase_address + 0x0FC;
+_GEN_EXCPT_ADDR         = _ebase_address + 0x180;
+_RESET_ADDR             = ORIGIN(kseg0_program_mem);
+_EEPROM_ADDR            = ORIGIN(kseg0_eeprom_mem);
+_BEV_EXCPT_ADDR         = 0xBFC00380;
+_DBG_EXCPT_ADDR         = 0xBFC00480;
+_DBG_CODE_ADDR          = ORIGIN(debug_exec_mem);
+
+/*************************************************************************
+ *  Bootloader program directives.
+ *  
+ * _IMAGE_TYPE
+ *
+ *  image type:
+ */
+     
+_imageReserved                      = 0x00000000 ;
+_imageMPIDE                         = 0x00000001 ;  /* This is a normal MPIDE sketch                                                                                                    */
+_imageBootFlashBootloader           = 0x00000002 ;  /* This is a boot flash bootloader                                                                                                  */
+_imageProgramFlashBootloader        = 0x00000004 ;  /* This is a program flash bootloader                                                                                               */
+_imageSplitFlashBootloader          = 0x00000008 ;  /* This has bootloader code in both boot and program flash                                                                          */
+
+ /*
+ *  Instructions for the bootloader
+ */
+                                                                       
+_imageFullFlashEraseLess4KEEProm    = 0x00010000 ;  /* The original bootloader method of erasing all of program flash except the last 4K reserved for eeprom                            */
+_imageJustInTimeFlashErase          = 0x00020000 ;  /* Only flash pages written too needed by the sketch is erased                                                                      */
+_imageLinkerSpecifiedFlashErase     = 0x00040000 ;  /* The linker defines the flash range to erase                                                                                      */
+_imageFullFlashErase                = 0x00080000 ;  /* All of flash is erased                                                                                                           */
+_imageExecutionJumpAddress          = 0x01000000 ;  /* the bootloader will jump to the execution jump address immediately after programming                                             */
+_imageExecutionJumpToFirstInFlash   = 0x02000000 ;  /* the bootloader will jump to the first sketch loaded in flash ignoring the execution jump address immediately after programming   */
+ 
+/*  
+ * _IMAGE_FLASH_SIZE 
+ *
+ *      Typically _imageJustInTimeFlashErase is selected to just erase the pages
+ *      of flash that code is written too; thus leaving all other flash pages untouched.
+ *  
+ *      If _imageLinkerSpecifiedFlashErase set, then the range
+ *      starting from _ebase_address for _IMAGE_FLASH_SIZE bytes are erased.
+ *
+ *      If _imageFullFlashErase is specified, than the whole flash
+ *      as known by the bootloader will be erased. This will erase eeprom as well
+ *
+ *      if _imageFullFlashEraseLess4KEEProm is set, all of flash less the last 4K is
+ *      erased, this is the old default. This bit could be set to make a program flash bootloader
+ *      erasing everything but the old flash. If NOTHING is set, this will be the default as this is the old behavior.
+ *  
+ *  _JUMP_ADDR
+ *  
+ *      This is the address that the bootloader will jump to start execution
+ *      of the sketch. This is almost always _RESET_ADDR.
+ *
+ *      However, you can specify an alternate entry execution point for example
+ *      if you have alternate starup code that, say, shared
+ *      the runtime with other sketches or needed some kind of specific handling
+ *
+ *      Immediately after programming (avrdude upload) the bootloader will typically
+ *      jump to the just loaded sketch, no matter where it was loaded in flash.
+ *      _imageExecutionJumpToFirstInFlash will tell the bootloader to jump to the first
+ *      sketch in flash even if the just loaded one is not at the beginning of flash.
+ *      This is useful when programming sketches in slots of flash and then always
+ *      jumping to the program-flash loader (vector sketch) as if the board was just reset.
+ *      This bit does not effect jumping to a sketch already in flash after reset.
+ *      As of today, after reset, the first program in flash will always be jumped to.
+ *
+ *************************************************************************/
+ _IMAGE_TYPE            = _imageMPIDE | _imageJustInTimeFlashErase | _imageExecutionJumpAddress;
+ _IMAGE_FLASH_SIZE      = LENGTH(exception_mem) + LENGTH(kseg0_program_mem);
+ _JUMP_ADDR             = _RESET_ADDR;
+
+SECTIONS
+{
+  /* Boot Sections */
+  .reset _RESET_ADDR :
+  {
+    KEEP(*(.reset))
+  } > kseg0_program_mem
+}
+
+/* From here out every linker script is the same, so just include it */
+/*INCLUDE "chipKIT-application-COMMON.ld"*/
+

--- a/hardware/pic32/cores/pic32/cpudefs.h
+++ b/hardware/pic32/cores/pic32/cpudefs.h
@@ -518,6 +518,20 @@
 		#define	RAMEND		((32 * 1024L) - 1)
 		#define	__PIC32MX4XX__
 
+    #elif defined(__32MX470F512H__)
+        #define _CPU_NAME_  "32MX470F512H"
+		#define	FLASHEND	(((512 - 4) * 1024L) - 1)
+		#define	RAMEND		((128 * 1024L) - 1)
+		#define	__PIC32MX47X__
+        #define __PIC32MX47XH__
+    
+    #elif defined(__32MX470F512L__)
+        #define _CPU_NAME_  "32MX470F512L"
+		#define	FLASHEND	(((512 - 4) * 1024L) - 1)
+		#define	RAMEND		((128 * 1024L) - 1)
+		#define	__PIC32MX47X__
+        #define __PIC32MX47XL__
+
 	//************************************************************************
 	//*	500 series
 

--- a/hardware/pic32/cores/pic32/p32_defs.h
+++ b/hardware/pic32/cores/pic32/p32_defs.h
@@ -81,7 +81,7 @@ typedef struct {
 
 /* This structure describes the register layout of an I/O port.
 */
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 typedef struct {
 	volatile p32_regset ansel;
 	volatile p32_regset	tris;
@@ -410,9 +410,202 @@ typedef struct {
 /*			Peripheral Pin Select Output Declarations			*/
 /* ------------------------------------------------------------ */
 
-/* Currently, PPS is only supported in PIC32MX1xx/PIC32MX2xx devices.
+/* Currently, PPS is only supported in PIC32MX1xx/PIC32MX2xx/PIC32MX47X devices.
 */
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
+#if defined(__PIC32MX47X__)
+
+#define _PPS_SET_A  0x0100
+#define _PPS_SET_B  0x0200
+#define _PPS_SET_C  0x0400
+#define _PPS_SET_D  0x0800
+
+typedef uint32_t p32_ppsout;
+
+#define _PPS_INPUT_BIT  (1 << 15)
+#define PPS_OUT_MASK    0x000F
+#define PPS_IN_MASK     0x00FF
+#define NUM_PPS_IN      51          // This must be set to the highest PPS_IN_xxx value
+#define NUM_PPS_OUT     0b1111      // This must be set to the highest PPS_OUT_xxx value
+
+typedef enum {
+    PPS_OUT_GPIO    = (0 + (_PPS_SET_A|_PPS_SET_B|_PPS_SET_C|_PPS_SET_D)),
+
+    PPS_OUT_U3TX    = (0b0001 + _PPS_SET_A),
+    PPS_OUT_U4RTS   = (0b0010 + _PPS_SET_A),
+    PPS_OUT_SDO2    = (0b0110 + (_PPS_SET_A | _PPS_SET_B)),
+    PPS_OUT_OC3     = (0b1011 + _PPS_SET_A),
+    PPS_OUT_C2OUT   = (0b1101 + _PPS_SET_A),
+
+    PPS_OUT_U2TX    = (0b0001 + _PPS_SET_B),
+    PPS_OUT_U1TX    = (0b0011 + _PPS_SET_B),
+    PPS_OUT_U5RTS   = (0b0100 + _PPS_SET_B),
+    PPS_OUT_SDO1    = (0b1000 + (_PPS_SET_B | _PPS_SET_C | _PPS_SET_D)),
+    PPS_OUT_OC4     = (0b1011 + _PPS_SET_B),
+
+    PPS_OUT_U3RTS   = (0b0001 + _PPS_SET_C),
+    PPS_OUT_U4TX    = (0b0010 + _PPS_SET_C),
+    PPS_OUT_REFCLKO = (0b0011 + _PPS_SET_C),
+    PPS_OUT_U5TX    = (0b0100 + (_PPS_SET_C | _PPS_SET_D)),
+    PPS_OUT_SS1     = (0b0111 + _PPS_SET_C),
+    PPS_OUT_OC5     = (0b1011 + _PPS_SET_C),
+    PPS_OUT_C1OUT   = (0b1101 + _PPS_SET_C),
+
+    PPS_OUT_U2RTS   = (0b0001 + _PPS_SET_D),
+    PPS_OUT_U1RTS   = (0b0011 + _PPS_SET_D),
+    PPS_OUT_SS2     = (0b0110 + _PPS_SET_D),
+    PPS_OUT_OC2     = (0b1011 + _PPS_SET_D),
+    PPS_OUT_OC1     = (0b1100 + _PPS_SET_D),
+
+    PPS_IN_INT1 = (0 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_INT2 = (1 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_INT3 = (2 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_INT4 = (3 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_T2CK = (5 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_T3CK = (6 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_T4CK = (7 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_T5CK = (8 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_IC1 = (9 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_IC2 = (10 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_IC3 = (11 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_IC4 = (12 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_IC5 = (13 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_OCFA = (17 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_U1RX = (19 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_U1CTS = (20 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_U2RX = (21 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_U2CTS = (22 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_U3RX = (23 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_U3CTS = (24 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_U4RX = (25 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_U4CTS = (26 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_U5RX = (27 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_U5CTS = (28 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_SDI1 = (32 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_SS1 = (33 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_SDI2 = (35 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_SS2 = (36 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_REFCLKI = (51 + _PPS_SET_A + _PPS_INPUT_BIT),
+
+} ppsFunctionType;
+
+typedef uint32_t p32_ppsin;
+
+#define _PPS_RPD2       ( 0 + _PPS_SET_A)
+#define _PPS_RPG8       ( 1 + _PPS_SET_A)
+#define _PPS_RPF4       ( 2 + _PPS_SET_A)
+#define _PPS_RPD10      ( 3 + _PPS_SET_A)
+#define _PPS_RPF1       ( 4 + _PPS_SET_A)
+#define _PPS_RPB9       ( 5 + _PPS_SET_A)
+#define _PPS_RPB10      ( 6 + _PPS_SET_A)
+#define _PPS_RPC14      ( 7 + _PPS_SET_A)
+#define _PPS_RPB5       ( 8 + _PPS_SET_A)
+#define _PPS_RPC1       (10 + _PPS_SET_A)
+#define _PPS_RPD14      (11 + _PPS_SET_A)
+#define _PPS_RPG1       (12 + _PPS_SET_A)
+#define _PPS_RPA14      (13 + _PPS_SET_A)
+#define _PPS_RPF2       (15 + _PPS_SET_A)
+
+#define _PPS_RPD3       ( 0 + _PPS_SET_B)
+#define _PPS_RPG7       ( 1 + _PPS_SET_B)
+#define _PPS_RPF5       ( 2 + _PPS_SET_B)
+#define _PPS_RPD11      ( 3 + _PPS_SET_B)
+#define _PPS_RPF0       ( 4 + _PPS_SET_B)
+#define _PPS_RPB1       ( 5 + _PPS_SET_B)
+#define _PPS_RPE5       ( 6 + _PPS_SET_B)
+#define _PPS_RPC13      ( 7 + _PPS_SET_B)
+#define _PPS_RPB3       ( 8 + _PPS_SET_B)
+#define _PPS_RPC4       (10 + _PPS_SET_B)
+#define _PPS_RPD15      (11 + _PPS_SET_B)
+#define _PPS_RPG0       (12 + _PPS_SET_B)
+#define _PPS_RPA15      (13 + _PPS_SET_B)
+#define _PPS_RPF2       (14 + _PPS_SET_B)
+#define _PPS_RPF7       (15 + _PPS_SET_B)
+
+#define _PPS_RPD9       ( 0 + _PPS_SET_C)
+#define _PPS_RPG6       ( 1 + _PPS_SET_C)
+#define _PPS_RPB8       ( 2 + _PPS_SET_C)
+#define _PPS_RPB15      ( 3 + _PPS_SET_C)
+#define _PPS_RPD4       ( 4 + _PPS_SET_C)
+#define _PPS_RPB0       ( 5 + _PPS_SET_C)
+#define _PPS_RPE3       ( 6 + _PPS_SET_C)
+#define _PPS_RPB7       ( 7 + _PPS_SET_C)
+#define _PPS_RPF12      ( 9 + _PPS_SET_C)
+#define _PPS_RPD12      (10 + _PPS_SET_C)
+#define _PPS_RPF8       (11 + _PPS_SET_C)
+#define _PPS_RPC3       (12 + _PPS_SET_C)
+#define _PPS_RPE9       (13 + _PPS_SET_C)
+#define _PPS_RPB2       (15 + _PPS_SET_C)
+
+#define _PPS_RPD1       ( 0 + _PPS_SET_D)
+#define _PPS_RPG9       ( 1 + _PPS_SET_D)
+#define _PPS_RPB14      ( 2 + _PPS_SET_D)
+#define _PPS_RPD0       ( 3 + _PPS_SET_D)
+#define _PPS_RPD8       ( 4 + _PPS_SET_D)
+#define _PPS_RPB6       ( 5 + _PPS_SET_D)
+#define _PPS_RPD5       ( 6 + _PPS_SET_D)
+#define _PPS_RPB2       ( 7 + _PPS_SET_D)
+#define _PPS_RPF3       ( 8 + _PPS_SET_D)
+#define _PPS_RPF13      ( 9 + _PPS_SET_D)
+#define _PPS_RPF2       (11 + _PPS_SET_D)
+#define _PPS_RPC2       (12 + _PPS_SET_D)
+#define _PPS_RPE8       (13 + _PPS_SET_D)
+
+#define _PPS_RPA14R    0
+#define _PPS_RPA15R    1
+#define _PPS_RPB0R    2
+#define _PPS_RPB1R    3
+#define _PPS_RPB2R    4
+#define _PPS_RPB3R    5
+#define _PPS_RPB5R    7
+#define _PPS_RPB6R    8
+#define _PPS_RPB7R    9
+#define _PPS_RPB8R    10
+#define _PPS_RPB9R    11
+#define _PPS_RPB10R    12
+#define _PPS_RPB14R    16
+#define _PPS_RPB15R    17
+#define _PPS_RPC1R    19
+#define _PPS_RPC2R    20
+#define _PPS_RPC3R    21
+#define _PPS_RPC4R    22
+#define _PPS_RPC13R    31
+#define _PPS_RPC14R    32
+#define _PPS_RPD0R    34
+#define _PPS_RPD1R    35
+#define _PPS_RPD2R    36
+#define _PPS_RPD3R    37
+#define _PPS_RPD4R    38
+#define _PPS_RPD5R    39
+#define _PPS_RPD8R    42
+#define _PPS_RPD9R    43
+#define _PPS_RPD10R    44
+#define _PPS_RPD11R    45
+#define _PPS_RPD12R    46
+#define _PPS_RPD14R    48
+#define _PPS_RPD15R    49
+#define _PPS_RPE3R    53
+#define _PPS_RPE5R    55
+#define _PPS_RPE8R    58
+#define _PPS_RPE9R    59
+#define _PPS_RPF0R    66
+#define _PPS_RPF1R    67
+#define _PPS_RPF2R    68
+#define _PPS_RPF3R    69
+#define _PPS_RPF4R    70
+#define _PPS_RPF5R    71
+#define _PPS_RPF6R    72
+#define _PPS_RPF8R    74
+#define _PPS_RPF12R    78
+#define _PPS_RPF13R    79
+#define _PPS_RPG0R    82
+#define _PPS_RPG1R    83
+#define _PPS_RPG6R    88
+#define _PPS_RPG7R    89
+#define _PPS_RPG8R    90
+#define _PPS_RPG9R    91
+
+
+#elif defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
 
 /* The PPS pins and peripheral functions are divided up into four sets.
 ** In some cases, the sets are disjoint, and in other cases there is

--- a/hardware/pic32/cores/pic32/pins_arduino.h
+++ b/hardware/pic32/cores/pic32/pins_arduino.h
@@ -147,7 +147,21 @@
 /* The following macros are used in building the data tables
 ** used by the hardware abstraction layer.
 */
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
+#if defined(__PIC32MX47XH__)
+
+#define _RPOBASE    RPB0R       //base address of PPS output select registers
+#define _RPIBASE    INT1R       //base address of PPS input select registers
+#define _PPS_OUT(P) (P)
+#define _PPS_IN(P) (uint8_t)(((P) & 0x0F) | ((P) >> 4))
+
+#elif defined(__PIC32MX47XL__)
+
+#define _RPOBASE    RPA14R      //base address of PPS output select registers
+#define _RPIBASE    INT1R       //base address of PPS input select registers
+#define _PPS_OUT(P) (P)
+#define _PPS_IN(P) (uint8_t)(((P) & 0x0F) | ((P) >> 4))
+
+#elif defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
 /* The following are used to build tables used to map pin numbers for
 ** PPS input and output selection.
 */
@@ -166,7 +180,7 @@
 #define	_PPS_OUT(P) (P)
 #define _PPS_IN(P) (uint8_t)(((P) & 0x0F) | ((P) >> 4))
 
-#endif	// defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#endif	// defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 
 /* ------------------------------------------------------------ */
 /*					Pin Mapping Macros							*/
@@ -186,7 +200,7 @@
 #define	digitalPinToTimer(P)	digitalPinToTimerOC(P)
 #define digitalPinToCN(P) (NOT_CN_PIN)
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 // This macro returns a pointer to a p32_ioport structure as defined in p32_defs.h
 // For MX1xx and MX2xx devices, the port register map starts with the ANSELx register.
 #define portRegisters(P) ((p32_ioport *)(port_to_tris_PGM[P] - 0x0010))
@@ -248,7 +262,7 @@
 /* Data tables for PPS pin mapping support defined in pins_arduino.h
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 #if !defined(OPT_BOARD_DATA)
 
 extern const uint8_t output_compare_to_pps_sel_PGM[];

--- a/hardware/pic32/cores/pic32/wiring.h
+++ b/hardware/pic32/cores/pic32/wiring.h
@@ -402,7 +402,7 @@ extern const uint32_t _IMAGE_HEADER_ADDR;                       // a pointer to 
 	extern unsigned int	__PIC32_pbClk;
 #endif
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZ__) 
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZ__)  || defined(__PIC32MX47X__)
 
 // PPS Support for PIC32MX1 and PIC32MX2 parts
 // Locks all PPS functions so that calls to mapPpsInput() or mapPpsOutput() always fail.
@@ -425,7 +425,7 @@ void unlockPps();
 // in a <pin> that can't be assigned to <func>, this function will return 'false'.
 boolean mapPps(uint8_t pin, ppsFunctionType func);
 
-#endif  // defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
+#endif  // defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MX47X__)
 
 #ifdef __cplusplus
 } // extern "C"

--- a/hardware/pic32/cores/pic32/wiring_analog.c
+++ b/hardware/pic32/cores/pic32/wiring_analog.c
@@ -150,7 +150,7 @@ int	tmp;
 	/* Ensure that the pin associated with the analog channel is in analog
 	** input mode, and select the channel in the input mux.
 	*/
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 	p32_ioport *	iop;
 	uint16_t		bit;
 
@@ -206,7 +206,7 @@ int	tmp;
 	**  bit in AD1PCFG.
 	*/
 	AD1PCFGCLR = (1 << channelNumber);
-#endif		// defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
+#endif		// defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MX47X__)
 
 #if defined(__PIC32MZXX__)
 
@@ -435,7 +435,7 @@ int	_board_analogWrite(uint8_t pin, int val);
             if ((pwm_active & pwm_mask) == 0)
             {
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
                 volatile uint32_t *	pps;
 
                 /* On devices with peripheral pin select, it is necessary to connect

--- a/hardware/pic32/cores/pic32/wiring_digital.c
+++ b/hardware/pic32/cores/pic32/wiring_digital.c
@@ -50,7 +50,7 @@ uint32_t				bit;
 uint8_t					port;
 volatile p32_ioport *	iop;
 uint8_t		            timer;
-#if !defined(__PIC32MX1XX__) && !defined(__PIC32MX2XX__) && !defined(__PIC32MZXX__)
+#if !defined(__PIC32MX1XX__) && !defined(__PIC32MX2XX__) && !defined(__PIC32MZXX__) && !defined(__PIC32MX47X__)
 uint32_t                cn;
 #endif
 
@@ -84,7 +84,7 @@ int	_board_pinMode(uint8_t pin, uint8_t mode)
 	//* Obtain bit mask for the specific bit for this pin.
 	bit = digitalPinToBitMask(pin);
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 	volatile uint32_t *	pps;
 
 	// The MX1xx/MX2xx support peripheral pin select (PPS). It is necessary
@@ -115,7 +115,7 @@ int	_board_pinMode(uint8_t pin, uint8_t mode)
 		AD1PCFGSET = bit;
 
 	}
-#endif	// defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
+#endif	// defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MX47X__)
 
 	// Set the pin to the requested mode.
     switch (mode) {
@@ -123,7 +123,7 @@ int	_board_pinMode(uint8_t pin, uint8_t mode)
         case INPUT_PULLUP:
         case INPUT_PULLDOWN:
         case INPUT_PULLUPDOWN:
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
             if (mode == INPUT_PULLUP) {
                 iop->cnpu.set = bit;
                 iop->cnpd.clr = bit;
@@ -173,7 +173,7 @@ int	_board_pinMode(uint8_t pin, uint8_t mode)
             // The behavior inherited from Arduino is that if INPUT wasn't
             // specified you get OUTPUT. That behavior is preserved rather
             // than error checking the input value.
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
             iop->cnpu.clr = bit;
             iop->cnpd.clr = bit;
 #else
@@ -261,7 +261,7 @@ volatile p32_ioport *	iop;
 uint8_t					port;
 uint16_t				bit;
 uint8_t					timer;
-#if !defined(__PIC32MX1XX__) && !defined(__PIC32MX2XX__) && !defined(__PIC32MZXX__)
+#if !defined(__PIC32MX1XX__) && !defined(__PIC32MX2XX__) && !defined(__PIC32MZXX__) && !defined(__PIC32MX47X__)
 uint32_t                cn;
 #endif
 
@@ -300,7 +300,7 @@ int	_board_digitalWrite(uint8_t pin, uint8_t val);
     //* resistor.  Only works for pins that have an associated
     //* change notification pin.
     if (iop->tris.reg & bit) {
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
         if (val == LOW) {
             iop->cnpu.clr = bit;
             iop->cnpd.clr = bit;
@@ -380,7 +380,7 @@ uint8_t	tmp;
 	//* Obtain bit mask for the specific bit for this pin.
 	bit = digitalPinToBitMask(pin);
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 	// The MX1xx-MX2xx devices have an ANSELx register associated with
 	// each io port that is used to control analog/digital mode of the
 	// analog input capable pins.
@@ -400,7 +400,7 @@ uint8_t	tmp;
 		AD1PCFGSET = bit;
 
 	}
-#endif	// defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
+#endif	// defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MX47X__)
 
 	//* Get the pin state.
 	if ((iop->port.reg & bit) != 0) 


### PR DESCRIPTION
The MX470 is an awkward chip to support.  It has PPS like the MX1/2, but is wildly different from the other MX4 chips.  So, a new category `__PIC32MX47X__` has had to be made.  On top of that there are differences between the L and H versions (different PPS pins available), so two further sub-categories of `__PIC32MX47XH__` and `__PIC32MX47XL__` have had to be made as well.
