### PR TITLE
Changed sample clock from 6Tpb to 22Tpb so external Vref works cleanly

### DIFF
--- a/hardware/pic32/cores/pic32/wiring_analog.c
+++ b/hardware/pic32/cores/pic32/wiring_analog.c
@@ -310,7 +310,7 @@ int	tmp;
 	/* Set up for manual sampling
 	*/
 	AD1CSSL	=	0;
-	AD1CON3	=	0x0002;	//Tad = internal 6 Tpb
+	AD1CON3	=	0x000B;	//Tad = internal 22 Tpb
 	AD1CON2	=	analog_reference;
 
 	/* Turn on ADC


### PR DESCRIPTION
It seems that too high a sample clock breaks ADC readings when using the external Aref+ pin.

Slowing the clock down to ~3.6MHz seems to fix the problem.

See: http://chipkit.net/forum/viewtopic.php?f=17&t=3024
