### PR TITLE
Fix MX470 support and add to DSPI

### DIFF
--- a/hardware/pic32/cores/pic32/p32_defs.h
+++ b/hardware/pic32/cores/pic32/p32_defs.h
@@ -550,6 +550,7 @@ typedef uint32_t p32_ppsin;
 #define _PPS_RPC2       (12 + _PPS_SET_D)
 #define _PPS_RPE8       (13 + _PPS_SET_D)
 
+#if defined(__PIC32MX47XL__)
 #define _PPS_RPA14R    0
 #define _PPS_RPA15R    1
 #define _PPS_RPB0R    2
@@ -603,6 +604,42 @@ typedef uint32_t p32_ppsin;
 #define _PPS_RPG7R    89
 #define _PPS_RPG8R    90
 #define _PPS_RPG9R    91
+#else
+#define _PPS_RPB0R    0
+#define _PPS_RPB1R    1
+#define _PPS_RPB2R    2
+#define _PPS_RPB3R    3
+#define _PPS_RPB5R    5
+#define _PPS_RPB6R    6
+#define _PPS_RPB7R    7
+#define _PPS_RPB8R    8
+#define _PPS_RPB9R    9 
+#define _PPS_RPB10R    10
+#define _PPS_RPB14R    14
+#define _PPS_RPB15R    15
+#define _PPS_RPC13R    29
+#define _PPS_RPC14R    30
+#define _PPS_RPD0R    32
+#define _PPS_RPD1R    33
+#define _PPS_RPD2R    34
+#define _PPS_RPD3R    35
+#define _PPS_RPD4R    36
+#define _PPS_RPD5R    37
+#define _PPS_RPD8R    40
+#define _PPS_RPD9R    41
+#define _PPS_RPD10R    42
+#define _PPS_RPD11R    43
+#define _PPS_RPE3R    51
+#define _PPS_RPE5R    53
+#define _PPS_RPF0R    64
+#define _PPS_RPF1R    65
+#define _PPS_RPF4R    68
+#define _PPS_RPF5R    69
+#define _PPS_RPG6R    86
+#define _PPS_RPG7R    87
+#define _PPS_RPG8R    88
+#define _PPS_RPG9R    89
+#endif
 
 
 #elif defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)

--- a/hardware/pic32/cores/pic32/wiring.c
+++ b/hardware/pic32/cores/pic32/wiring.c
@@ -244,7 +244,7 @@ void	_board_init(void);
 //*
 /* Currently, PPS is only available in PIC32MX1xx/PIC32MX2xx devices.
 */
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZ__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZ__) || defined(__PIC32MX47X__)
 
 // Locks all PPS functions so that calls to mapPpsInput() or mapPpsOutput() always fail.
 // You would use this function if you set up all of your PPS settings at the beginning

--- a/hardware/pic32/libraries/DSPI/DSPI.cpp
+++ b/hardware/pic32/libraries/DSPI/DSPI.cpp
@@ -115,7 +115,7 @@ static DSPI *	pdspi3 = 0;
 **		can be instantiated.
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 DSPI::DSPI(int pinMI, int pinMO, ppsFunctionType ppsMI, ppsFunctionType ppsMO)
 #else
 DSPI::DSPI()
@@ -125,7 +125,7 @@ DSPI::DSPI()
 	pspi = 0;
 	cbCur = 0;
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 	pinMISO = (uint8_t)pinMI;
 	pinMOSI = (uint8_t)pinMO;
 	ppsMISO = ppsMI;
@@ -174,7 +174,7 @@ DSPI::init(uint8_t irqErr, uint8_t irqRx, uint8_t irqTx, isrFunc isrHandler) {
     isr = isrHandler;
 }
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 
 /* ------------------------------------------------------------ */
 /***	DSPI::begin
@@ -275,13 +275,17 @@ DSPI::begin(uint8_t pinT) {
 	uint8_t			bTmp;
 	uint16_t		brg;
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
-	/* Map the SPI MISO to the appropriate pin.
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+	/* Map the SPI MISO to the appropriate pin.  Some chips need the
+       pins to be set to the right mode, either for the IO functionality
+       or to disable any analog on the pin.
 	*/
+    pinMode(pinMISO, INPUT);
     mapPps(pinMISO, ppsMISO);
 
 	/* Map the SPI MOSI to the appropriate pin.
 	*/
+    pinMode(pinMOSI, OUTPUT);
     mapPps(pinMOSI, ppsMOSI);
 #endif
 
@@ -1030,7 +1034,7 @@ DSPI::doDspiInterrupt() {
 **		Constructor.
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 DSPI0::DSPI0() : DSPI(_DSPI0_MISO_PIN, _DSPI0_MOSI_PIN, _DSPI0_MISO_IN, _DSPI0_MOSI_OUT)
 #else
 DSPI0::DSPI0() 
@@ -1115,7 +1119,7 @@ DSPI0::disableInterruptTransfer() {
 **		Constructor.
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 DSPI1::DSPI1() : DSPI(_DSPI1_MISO_PIN, _DSPI1_MOSI_PIN, _DSPI1_MISO_IN, _DSPI1_MOSI_OUT)
 #else
 DSPI1::DSPI1()
@@ -1201,7 +1205,7 @@ DSPI1::disableInterruptTransfer() {
 **		Constructor.
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 DSPI2::DSPI2() : DSPI(_DSPI2_MISO_PIN, _DSPI2_MOSI_PIN, _DSPI2_MISO_IN, _DSPI2_MOSI_OUT)
 #else
 DSPI2::DSPI2()
@@ -1286,7 +1290,7 @@ DSPI2::disableInterruptTransfer() {
 **		Constructor.
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 DSPI3::DSPI3() : DSPI(_DSPI3_MISO_PIN, _DSPI3_MOSI_PIN, _DSPI3_MISO_IN, _DSPI3_MOSI_OUT)
 #else
 DSPI3::DSPI3()

--- a/hardware/pic32/libraries/DSPI/DSPI.h
+++ b/hardware/pic32/libraries/DSPI/DSPI.h
@@ -102,7 +102,7 @@ private:
 	uint8_t				bPad;		//pad byte for some transfers
 	uint8_t				fRov;		//receive overflow error flag
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 	uint8_t				pinMISO;		//digital pin number for MISO
 	uint8_t				pinMOSI;		//digital pin number for MOSI
 	ppsFunctionType		ppsMISO;		//PPS select for SPI MISO
@@ -118,7 +118,7 @@ protected:
 	uint8_t				ipl;		//interrupt priority and sub-priority
 	uint8_t				pinSS;		//digital pin number for slave select pin
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 			DSPI (int pinMI, int pinMO, ppsFunctionType ppsMI, ppsFunctionType ppsMO);
 #else
 			DSPI();
@@ -132,7 +132,7 @@ public:
 */
 void		begin();
 void		begin(uint8_t pin);
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 void        begin(uint8_t miso, uint8_t mosi);
 void        begin(uint8_t miso, uint8_t mosi, uint8_t pin);
 #endif


### PR DESCRIPTION
A few fixes to the MX470 chips support (differences between H and L
versions) and added MX470 support to the DSPI library (pin mappings).
