### PR TITLE
Fix interrups, add DTWI, fix Wire, fix timer for MZ

### DIFF
--- a/hardware/pic32/boards.txt
+++ b/hardware/pic32/boards.txt
@@ -37,43 +37,6 @@ uno_pic32.build.variant=Uno32
 #uno_pic32.upload.using=
 
 ############################################################
-uno_pic32_dbg.name=chipKIT UNO32 - MPLAB Debug
-
-# new items
-uno_pic32_dbg.group=chipKIT
-uno_pic32_dbg.platform=pic32
-uno_pic32_dbg.board=_BOARD_UNO_
-uno_pic32_dbg.board.define=
-uno_pic32_dbg.compiler.define=
-uno_pic32_dbg.ccflags=ffff
-uno_pic32_dbg.ldscript=chipKIT-application-32MX320F128-nobootloader.ld
-# end of new items
-
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-uno_pic32_dbg.compiler.c.flags=-O0::-c::-mno-smart-io::-w::-ffunction-sections::-fdata-sections::-G1024::-g::-mdebugger::-Wcast-align::-fno-short-double
-uno_pic32_dbg.compiler.cpp.flags=-O0::-c::-mno-smart-io::-w::-fno-exceptions::-ffunction-sections::-fdata-sections::-G1024::-g::-mdebugger::-Wcast-align::-fno-short-double
-
-uno_pic32_dbg.upload.protocol=stk500v2
-uno_pic32_dbg.upload.maximum_size=126976
-uno_pic32_dbg.upload.speed=115200
-
-uno_pic32_dbg.bootloader.low_fuses=0xff
-uno_pic32_dbg.bootloader.high_fuses=0xdd
-uno_pic32_dbg.bootloader.extended_fuses=0x00
-uno_pic32_dbg.bootloader.path=not-supported
-uno_pic32_dbg.bootloader.file=not-supported
-uno_pic32_dbg.bootloader.unlock_bits=0x3F
-uno_pic32_dbg.bootloader.lock_bits=0x0F
-
-uno_pic32_dbg.build.mcu=32MX320F128H
-uno_pic32_dbg.build.f_cpu=80000000L
-uno_pic32_dbg.build.core=pic32
-uno_pic32_dbg.build.variant=Uno32
-#uno_pic32_dbg.upload.using=
-
-############################################################
 mega_pic32.name=chipKIT MAX32
 mega_pic32.group=chipKIT
 
@@ -133,41 +96,6 @@ mega_usb_pic32.build.core=pic32
 mega_usb_pic32.build.variant=Max32
 #mega_usb_pic32.upload.using=
 
-############################################################
-#mega_usb_debug_pic32.name=chipKIT MAX32-USB for Serial Debug
-#
-## new items
-#mega_usb_debug_pic32.platform=pic32
-#mega_usb_debug_pic32.board=_BOARD_MEGA_
-#mega_usb_debug_pic32.board.define=-D_USE_USB_FOR_SERIAL_
-#mega_usb_debug_pic32.ccflags=-Map="map.map"
-#mega_usb_debug_pic32.ldscript=chipKIT-MAX32-application-32MX795F512-nobootloader.ld
-## end of new items
-#
-## Use a high -Gnum for devices that have less than 64K of data memory
-## For -G1024, objects 1024 bytes or smaller will be accessed by
-## gp-relative addressing
-#mega_usb_debug_pic32.compiler.c.flags=-O0::-c::-mno-smart-io::-w::-ffunction-sections::-fdata-sections::-G1024::-g::-mdebugger::-Wcast-align::-fno-short-double
-#mega_usb_debug_pic32.compiler.cpp.flags=-O0::-c::-mno-smart-io::-w::-fno-exceptions::-ffunction-sections::-fdata-sections::-G1024::-g::-mdebugger::-Wcast-align::-fno-short-double
-#
-#mega_usb_debug_pic32.upload.protocol=stk500v2
-#mega_usb_debug_pic32.upload.maximum_size=520192
-#mega_usb_debug_pic32.upload.speed=115200
-#
-#mega_usb_debug_pic32.bootloader.low_fuses=0xff
-#mega_usb_debug_pic32.bootloader.high_fuses=0xdd
-#mega_usb_debug_pic32.bootloader.extended_fuses=0x00
-#mega_usb_debug_pic32.bootloader.path=not-supported
-#mega_usb_debug_pic32.bootloader.file=not-supported
-#mega_usb_debug_pic32.bootloader.unlock_bits=0x3F
-#mega_usb_debug_pic32.bootloader.lock_bits=0x0F
-#
-#mega_usb_debug_pic32.build.mcu=32MX795F512L
-#mega_usb_debug_pic32.build.f_cpu=80000000L
-#mega_usb_debug_pic32.build.core=pic32
-#mega_usb_debug_pic32.build.variant=Max32
-##mega_usb_pic32.upload.using=
-#
 ############################################################
 chipkit_uc32.name=chipKIT uC32
 chipkit_uc32.group=chipKIT
@@ -432,39 +360,6 @@ chipkit_pro_mx7.build.core=pic32
 chipkit_pro_mx7.build.variant=Cerebot_MX7cK
 #chipkit_pro_mx7.upload.using=
 
-############################################################
-#MX7ck_dbg.name=Cerebot MX7cK - MPLAB Debug
-#
-## new items
-#MX7ck_dbg.platform=pic32
-#MX7ck_dbg.board=_BOARD_CEREBOT_MX7CK_
-#MX7ck_dbg.board.define=
-#MX7ck_dbg.ccflags=ffff
-#MX7ck_dbg.ldscript=chipKIT-application-32MX795F512L-nobootloader.ld
-## end of new items
-#
-## Override the compiler flags to turn off optimizations
-#MX7ck_dbg.compiler.c.flags=-O0::-c::-mno-smart-io::-w::-ffunction-sections::-fdata-sections::-g::-mdebugger::-Wcast-align::-fno-short-double::-save-temps::-g3
-#MX7ck_dbg.compiler.cpp.flags=-O0::-c::-mno-smart-io::-w::-fno-exceptions::-ffunction-sections::-fdata-sections::-g::-mdebugger::-Wcast-align::-fno-short-double
-#
-#MX7ck_dbg.upload.protocol=stk500v2
-#MX7ck_dbg.upload.maximum_size=520192
-#MX7ck_dbg.upload.speed=115200
-#
-#MX7ck_dbg.bootloader.low_fuses=0xff
-#MX7ck_dbg.bootloader.high_fuses=0xdd
-#MX7ck_dbg.bootloader.extended_fuses=0x00
-#MX7ck_dbg.bootloader.path=not-supported
-#MX7ck_dbg.bootloader.file=not-supported
-#MX7ck_dbg.bootloader.unlock_bits=0x3F
-#MX7ck_dbg.bootloader.lock_bits=0x0F
-#
-#MX7ck_dbg.build.mcu=32MX795F512L
-#MX7ck_dbg.build.f_cpu=80000000L
-#MX7ck_dbg.build.core=pic32
-#MX7ck_dbg.build.variant=Cerebot_MX7cK
-##MX7ck_dbg.upload.using=
-#
 ############################################################
 cerebot32mx4.name=Cerebot 32MX4
 cerebot32mx4.group=Cerebot

--- a/hardware/pic32/cores/pic32/System_Defs.h
+++ b/hardware/pic32/cores/pic32/System_Defs.h
@@ -18,7 +18,7 @@
 /*	12/20/2011(GeneApperson): Added task manager declarations			*/
 /*	07/26/2012(GeneApperson): Added PPS support for PIC32MX1xx/MX2xx	*/
 /*		devices															*/
-//*	Feb 17, 2014	<KeithV> Added PPS support for MZ devices
+/*	Feb 17, 2014	<KeithV> Added PPS support for MZ devices           */
 /*  03/24/2014(BrianSchmalz): Added support for MX1/MX2 EEPROM emulation*/
 /*																		*/
 /************************************************************************/
@@ -113,23 +113,6 @@
     #define	NUM_INT_REQUEST	191
     #define NUM_EXTERNAL_INTERRUPTS	5
 
-    #define _UART1_BASE_ADDRESS ((uint32_t) &U1MODE)
-    #define _UART2_BASE_ADDRESS ((uint32_t) &U2MODE)
-    #define _UART3_BASE_ADDRESS ((uint32_t) &U3MODE)
-    #define _UART4_BASE_ADDRESS ((uint32_t) &U4MODE)
-    #define _UART5_BASE_ADDRESS ((uint32_t) &U5MODE)
-    #define _UART6_BASE_ADDRESS ((uint32_t) &U6MODE)
-
-    #define _SPI1_BASE_ADDRESS ((uint32_t) &SPI1CON)
-    #define _SPI2_BASE_ADDRESS ((uint32_t) &SPI2CON)
-    #define _SPI3_BASE_ADDRESS ((uint32_t) &SPI3CON)
-    #define _SPI4_BASE_ADDRESS ((uint32_t) &SPI4CON)
-    #define _SPI5_BASE_ADDRESS ((uint32_t) &SPI5CON)
-    #define _SPI6_BASE_ADDRESS ((uint32_t) &SPI6CON)
-
-    #define  _OCMP1_BASE_ADDRESS ((uint32_t) &OC1CON)
-    #define  _TIMER_1_IRQ _TIMER_1_VECTOR
-
 #endif
 
 /* Symbols for referring to the external interrupts
@@ -165,185 +148,185 @@
 
 /* Core Software Interrupts
 */
-#define	_CS0_IPL_ISR	ipl2
+#define	_CS0_IPL_ISR	IPL2SOFT
 #define	_CS0_IPL_IPC	2
 #define	_CS0_SPL_IPC	0
 
-#define	_CS1_IPL_ISR	ipl2
+#define	_CS1_IPL_ISR	IPL2SOFT
 #define	_CS1_IPL_IPC	2
 #define	_CS1_SPL_IPC	0
 
 /* External Interrupts.
 */
-#define	_INT0_IPL_ISR	ipl4
+#define	_INT0_IPL_ISR	IPL4SOFT
 #define	_INT0_IPL_IPC	4
 #define	_INT0_SPL_IPC	0
 
-#define	_INT1_IPL_ISR	ipl4
+#define	_INT1_IPL_ISR	IPL4SOFT
 #define	_INT1_IPL_IPC	4
 #define	_INT1_SPL_IPC	0
 
-#define	_INT2_IPL_ISR	ipl4
+#define	_INT2_IPL_ISR	IPL4SOFT
 #define	_INT2_IPL_IPC	4
 #define	_INT2_SPL_IPC	0
 
-#define	_INT3_IPL_ISR	ipl4
+#define	_INT3_IPL_ISR	IPL4SOFT
 #define	_INT3_IPL_IPC	4
 #define	_INT3_SPL_IPC	0
 
-#define	_INT4_IPL_ISR	ipl4
+#define	_INT4_IPL_ISR	IPL4SOFT
 #define	_INT4_IPL_IPC	4
 #define	_INT4_SPL_IPC	0
 
 /* Timer Interrupts
 */
-#define	_T1_IPL_ISR	ipl3
+#define	_T1_IPL_ISR	IPL3SOFT
 #define	_T1_IPL_IPC	3
 #define	_T1_SPL_IPC	0
 
-#define	_T2_IPL_ISR	ipl2
+#define	_T2_IPL_ISR	IPL2SOFT
 #define	_T2_IPL_IPC	2
 #define	_T2_SPL_IPC	0
 
-#define	_T3_IPL_ISR	ipl4
+#define	_T3_IPL_ISR	IPL4SOFT
 #define	_T3_IPL_IPC	4
 #define	_T3_SPL_IPC	0
 
-#define	_T4_IPL_ISR	ipl4
+#define	_T4_IPL_ISR	IPL4SOFT
 #define	_T4_IPL_IPC	4
 #define	_T4_SPL_IPC	0
 
-#define	_T5_IPL_ISR	ipl4
+#define	_T5_IPL_ISR	IPL4SOFT
 #define	_T5_IPL_IPC	4
 #define	_T5_SPL_IPC	0
 
-#define	_T6_IPL_ISR	ipl4
+#define	_T6_IPL_ISR	IPL4SOFT
 #define	_T6_IPL_IPC	4
 #define	_T6_SPL_IPC	0
 
-#define	_T7_IPL_ISR	ipl4
+#define	_T7_IPL_ISR	IPL4SOFT
 #define	_T7_IPL_IPC	4
 #define	_T7_SPL_IPC	0
 
-#define	_T8_IPL_ISR	ipl4
+#define	_T8_IPL_ISR	IPL4SOFT
 #define	_T8_IPL_IPC	4
 #define	_T8_SPL_IPC	0
 
-#define	_T9_IPL_ISR	ipl4
+#define	_T9_IPL_ISR	IPL4SOFT
 #define	_T9_IPL_IPC	4
 #define	_T9_SPL_IPC	0
 
 /* Input Capture Interrupts
 */
-#define	_IC1_IPL_ISR	ipl2
+#define	_IC1_IPL_ISR	IPL2SOFT
 #define	_IC1_IPL_IPC	2
 #define	_IC1_SPL_IPC	0
 
-#define	_IC2_IPL_ISR	ipl2
+#define	_IC2_IPL_ISR	IPL2SOFT
 #define	_IC2_IPL_IPC	2
 #define	_IC2_SPL_IPC	0
 
-#define	_IC3_IPL_ISR	ipl2
+#define	_IC3_IPL_ISR	IPL2SOFT
 #define	_IC3_IPL_IPC	2
 #define	_IC3_SPL_IPC	0
 
-#define	_IC4_IPL_ISR	ipl2
+#define	_IC4_IPL_ISR	IPL2SOFT
 #define	_IC4_IPL_IPC	2
 #define	_IC4_SPL_IPC	0
 
-#define	_IC5_IPL_ISR	ipl2
+#define	_IC5_IPL_ISR	IPL2SOFT
 #define	_IC5_IPL_IPC	2
 #define	_IC5_SPL_IPC	0
 
-#define	_IC6_IPL_ISR	ipl2
+#define	_IC6_IPL_ISR	IPL2SOFT
 #define	_IC6_IPL_IPC	2
 #define	_IC6_SPL_IPC	0
 
-#define	_IC7_IPL_ISR	ipl2
+#define	_IC7_IPL_ISR	IPL2SOFT
 #define	_IC7_IPL_IPC	2
 #define	_IC7_SPL_IPC	0
 
-#define	_IC8_IPL_ISR	ipl2
+#define	_IC8_IPL_ISR	IPL2SOFT
 #define	_IC8_IPL_IPC	2
 #define	_IC8_SPL_IPC	0
 
-#define	_IC9_IPL_ISR	ipl2
+#define	_IC9_IPL_ISR	IPL2SOFT
 #define	_IC9_IPL_IPC	2
 #define	_IC9_SPL_IPC	0
 
 /* Input Capture Error Interrupts
 */
-#define	_IC1E_IPL_ISR	ipl2
+#define	_IC1E_IPL_ISR	IPL2SOFT
 #define	_IC1E_IPL_IPC	2
 #define	_IC1E_SPL_IPC	0
 
-#define	_IC2E_IPL_ISR	ipl2
+#define	_IC2E_IPL_ISR	IPL2SOFT
 #define	_IC2E_IPL_IPC	2
 #define	_IC2E_SPL_IPC	0
 
-#define	_IC3E_IPL_ISR	ipl2
+#define	_IC3E_IPL_ISR	IPL2SOFT
 #define	_IC3E_IPL_IPC	2
 #define	_IC3E_SPL_IPC	0
 
-#define	_IC4E_IPL_ISR	ipl2
+#define	_IC4E_IPL_ISR	IPL2SOFT
 #define	_IC4E_IPL_IPC	2
 #define	_IC4E_SPL_IPC	0
 
-#define	_IC5E_IPL_ISR	ipl2
+#define	_IC5E_IPL_ISR	IPL2SOFT
 #define	_IC5E_IPL_IPC	2
 #define	_IC5E_SPL_IPC	0
 
-#define	_IC6E_IPL_ISR	ipl2
+#define	_IC6E_IPL_ISR	IPL2SOFT
 #define	_IC6E_IPL_IPC	2
 #define	_IC6E_SPL_IPC	0
 
-#define	_IC7E_IPL_ISR	ipl2
+#define	_IC7E_IPL_ISR	IPL2SOFT
 #define	_IC7E_IPL_IPC	2
 #define	_IC7E_SPL_IPC	0
 
-#define	_IC8E_IPL_ISR	ipl2
+#define	_IC8E_IPL_ISR	IPL2SOFT
 #define	_IC8E_IPL_IPC	2
 #define	_IC8E_SPL_IPC	0
 
-#define	_IC9E_IPL_ISR	ipl2
+#define	_IC9E_IPL_ISR	IPL2SOFT
 #define	_IC9E_IPL_IPC	2
 #define	_IC9E_SPL_IPC	0
 
 /* Output Compare Interrupts
 */
-#define	_OC1_IPL_ISR	ipl2
+#define	_OC1_IPL_ISR	IPL2SOFT
 #define	_OC1_IPL_IPC	2
 #define	_OC1_SPL_IPC	0
 
-#define	_OC2_IPL_ISR	ipl2
+#define	_OC2_IPL_ISR	IPL2SOFT
 #define	_OC2_IPL_IPC	2
 #define	_OC2_SPL_IPC	0
 
-#define	_OC3_IPL_ISR	ipl2
+#define	_OC3_IPL_ISR	IPL2SOFT
 #define	_OC3_IPL_IPC	2
 #define	_OC3_SPL_IPC	0
 
-#define	_OC4_IPL_ISR	ipl2
+#define	_OC4_IPL_ISR	IPL2SOFT
 #define	_OC4_IPL_IPC	2
 #define	_OC4_SPL_IPC	0
 
-#define	_OC5_IPL_ISR	ipl2
+#define	_OC5_IPL_ISR	IPL2SOFT
 #define	_OC5_IPL_IPC	2
 #define	_OC5_SPL_IPC	0
 
-#define	_OC6_IPL_ISR	ipl2
+#define	_OC6_IPL_ISR	IPL2SOFT
 #define	_OC6_IPL_IPC	2
 #define	_OC6_SPL_IPC	0
 
-#define	_OC7_IPL_ISR	ipl2
+#define	_OC7_IPL_ISR	IPL2SOFT
 #define	_OC7_IPL_IPC	2
 #define	_OC7_SPL_IPC	0
 
-#define	_OC8_IPL_ISR	ipl2
+#define	_OC8_IPL_ISR	IPL2SOFT
 #define	_OC8_IPL_IPC	2
 #define	_OC8_SPL_IPC	0
 
-#define	_OC9_IPL_ISR	ipl2
+#define	_OC9_IPL_ISR	IPL2SOFT
 #define	_OC9_IPL_IPC	2
 #define	_OC9_SPL_IPC	0
 
@@ -359,38 +342,38 @@
 
 /* UARTS
 */
-#define	_UART1_IPL_ISR	ipl2	//interrupt priority for ISR
+#define	_UART1_IPL_ISR	IPL2SOFT	//interrupt priority for ISR
 #define	_UART1_IPL_IPC	2		//interrupt priority for IPC register
 #define	_UART1_SPL_IPC	0		//interrupt subpriority for IPC register
 
-#define	_UART2_IPL_ISR	ipl2	//interrupt priority for ISR
+#define	_UART2_IPL_ISR	IPL2SOFT	//interrupt priority for ISR
 #define	_UART2_IPL_IPC	2		//interrupt priority for IPC register
 #define	_UART2_SPL_IPC	0		//interrupt subpriority for IPC register
 
-#define	_UART3_IPL_ISR	ipl2	//interrupt priority for ISR
+#define	_UART3_IPL_ISR	IPL2SOFT	//interrupt priority for ISR
 #define	_UART3_IPL_IPC	2		//interrupt priority for IPC register
 #define	_UART3_SPL_IPC	0		//interrupt subpriority for IPC register
 
-#define	_UART4_IPL_ISR	ipl2	//interrupt priority for ISR
+#define	_UART4_IPL_ISR	IPL2SOFT	//interrupt priority for ISR
 #define	_UART4_IPL_IPC	2		//interrupt priority for IPC register
 #define	_UART4_SPL_IPC	0		//interrupt subpriority for IPC register
 
-#define	_UART5_IPL_ISR	ipl2	//interrupt priority for ISR
+#define	_UART5_IPL_ISR	IPL2SOFT	//interrupt priority for ISR
 #define	_UART5_IPL_IPC	2		//interrupt priority for IPC register
 #define	_UART5_SPL_IPC	0		//interrupt subpriority for IPC register
 
-#define	_UART6_IPL_ISR	ipl2	//interrupt priority for ISR
+#define	_UART6_IPL_ISR	IPL2SOFT	//interrupt priority for ISR
 #define	_UART6_IPL_IPC	2		//interrupt priority for IPC register
 #define	_UART6_SPL_IPC	0		//interrupt subpriority for IPC register
 
 /* SPI Controllers
 */
-#define	_SPI1_IPL_ISR	ipl3	//interrupt priority for the ISR
+#define	_SPI1_IPL_ISR	IPL3SOFT	//interrupt priority for the ISR
 #define	_SPI1_IPL_IPC	3		//interrupt priority for the IPC register
 #define	_SPI1_SPL_IPC	0		//interrupt subpriority for the IPC register
 
 #if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MX3XX__) || defined(__PIC32MX4XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
-#define	_SPI2_IPL_ISR	ipl3    //interrupt priority for the ISR
+#define	_SPI2_IPL_ISR	IPL3SOFT    //interrupt priority for the ISR
 #define	_SPI2_IPL_IPC	3       //interrupt priority for the IPC register
 #define	_SPI2_SPL_IPC	0       //interrupt subpriority for the IPC register
 #endif
@@ -410,22 +393,22 @@
 #endif
 
 #if  defined(__PIC32MZXX__)
-#define	_SPI3_IPL_ISR	ipl3    //interrupt priority for the ISR
+#define	_SPI3_IPL_ISR	IPL3SRS    //interrupt priority for the ISR
 #define	_SPI3_IPL_IPC	3       //interrupt priority for the IPC register
 #define	_SPI3_SPL_IPC	0       //interrupt subpriority for the IPC register
 
-#define	_SPI4_IPL_ISR	ipl3    //interrupt priority for the ISR
+#define	_SPI4_IPL_ISR	IPL3SRS    //interrupt priority for the ISR
 #define	_SPI4_IPL_IPC	3       //interrupt priority for the IPC register
 #define	_SPI4_SPL_IPC	0       //interrupt subpriority for the IPC register
 #endif
 
 /* I2C Controllers
 */
-#define	_I2C1_IPL_ISR	ipl3	//interrupt priority for ISR
+#define	_I2C1_IPL_ISR	IPL3SOFT	//interrupt priority for ISR
 #define	_I2C1_IPL_IPC	3		//interrupt priority for IPC register
 #define	_I2C1_SPL_IPC	0		//interrupt subpriority for IPC register
 
-#define	_I2C2_IPL_ISR	ipl3	//interrupt priority for ISR
+#define	_I2C2_IPL_ISR	IPL3SOFT	//interrupt priority for ISR
 #define	_I2C2_IPL_IPC	3		//interrupt priority for IPC register
 #define	_I2C2_SPL_IPC	0		//interrupt subpriority for IPC register
 
@@ -444,120 +427,120 @@
 #endif
 
 #if  defined(__PIC32MZXX__)
-#define	_I2C3_IPL_ISR	ipl3	//interrupt priority for ISR
+#define	_I2C3_IPL_ISR	IPL3SRS	//interrupt priority for ISR
 #define	_I2C3_IPL_IPC	3		//interrupt priority for IPC register
 #define	_I2C3_SPL_IPC	0		//interrupt subpriority for IPC register
 
-#define	_I2C4_IPL_ISR	ipl3	//interrupt priority for ISR
+#define	_I2C4_IPL_ISR	IPL3SRS	//interrupt priority for ISR
 #define	_I2C4_IPL_IPC	3		//interrupt priority for IPC register
 #define	_I2C4_SPL_IPC	0		//interrupt subpriority for IPC register
 #endif
 
 /* Input Change Interrupt
 */
-#define	_CN_IPL_ISR		ipl1
+#define	_CN_IPL_ISR		IPL1SOFT
 #define	_CN_IPL_IPC		1
 #define	_CN_SPL_IPC		0
 
 /* Analog to Digital Converter Interrupt
 */
-#define	_ADC_IPL_ISR	ipl2
+#define	_ADC_IPL_ISR	IPL2SOFT
 #define	_ADC_IPL_IPC	2
 #define	_ADC_SPL_IPC	0
 
 /* Parallel Master Port Interrupt
 */
-#define	_PMP_IPL_ISR	ipl2
+#define	_PMP_IPL_ISR	IPL2SOFT
 #define	_PMP_IPL_IPC	2
 #define	_PMP_SPL_IPC	0
 
 /* Parallel Master Port Error Interrupt
 */
-#define	_PMPE_IPL_ISR	ipl2
+#define	_PMPE_IPL_ISR	IPL2SOFT
 #define	_PMPE_IPL_IPC	2
 #define	_PMPE_SPL_IPC	0
 
 /* Analog Comparator Interrupts
 */
-#define	_CMP1_IPL_ISR	ipl2
+#define	_CMP1_IPL_ISR	IPL2SOFT
 #define	_CMP1_IPL_IPC	2
 #define	_CMP1_SPL_IPC	0
 
-#define	_CMP2_IPL_ISR	ipl2
+#define	_CMP2_IPL_ISR	IPL2SOFT
 #define	_CMP2_IPL_IPC	2
 #define	_CMP2_SPL_IPC	0
 
 /* Fail-Safe Clock Monitor (FSCM) Interrupt
 */
-#define	_FSCM_IPL_ISR	ipl2
+#define	_FSCM_IPL_ISR	IPL2SOFT
 #define	_FSCM_IPL_IPC	2
 #define	_FSCM_SPL_IPC	0
 
 /* Real Time Clock/Calendar Interrupt
 */
-#define	_RTCC_IPL_ISR	ipl2
+#define	_RTCC_IPL_ISR	IPL2SOFT
 #define	_RTCC_IPL_IPC	2
 #define	_RTCC_SPL_IPC	0
 
 /* DMA Interrupts
 */
-#define	_DMA0_IPL_ISR	ipl2
+#define	_DMA0_IPL_ISR	IPL2SOFT
 #define	_DMA0_IPL_IPC	2
 #define	_DMA0_SPL_IPC	0
 
-#define	_DMA1_IPL_ISR	ipl2
+#define	_DMA1_IPL_ISR	IPL2SOFT
 #define	_DMA1_IPL_IPC	2
 #define	_DMA1_SPL_IPC	0
 
-#define	_DMA2_IPL_ISR	ipl2
+#define	_DMA2_IPL_ISR	IPL2SOFT
 #define	_DMA2_IPL_IPC	2
 #define	_DMA2_SPL_IPC	0
 
-#define	_DMA3_IPL_ISR	ipl2
+#define	_DMA3_IPL_ISR	IPL2SOFT
 #define	_DMA3_IPL_IPC	2
 #define	_DMA3_SPL_IPC	0
 
-#define	_DMA4_IPL_ISR	ipl2
+#define	_DMA4_IPL_ISR	IPL2SOFT
 #define	_DMA4_IPL_IPC	2
 #define	_DMA4_SPL_IPC	0
 
-#define	_DMA5_IPL_ISR	ipl2
+#define	_DMA5_IPL_ISR	IPL2SOFT
 #define	_DMA5_IPL_IPC	2
 #define	_DMA5_SPL_IPC	0
 
-#define	_DMA6_IPL_ISR	ipl2
+#define	_DMA6_IPL_ISR	IPL2SOFT
 #define	_DMA6_IPL_IPC	2
 #define	_DMA6_SPL_IPC	0
 
-#define	_DMA7_IPL_ISR	ipl2
+#define	_DMA7_IPL_ISR	IPL2SOFT
 #define	_DMA7_IPL_IPC	2
 #define	_DMA7_SPL_IPC	0
 
 /* Flash Control Event Interrupt
 */
-#define	_FCE_IPL_ISR	ipl2
+#define	_FCE_IPL_ISR	IPL2SOFT
 #define	_FCE_IPL_IPC	2
 #define	_FCE_SPL_IPC	0
 
 /* USB Interrupt
 */
-#define	_USB_IPL_ISR	ipl6
+#define	_USB_IPL_ISR	IPL6SOFT
 #define	_USB_IPL_IPC	6
 #define	_USB_SPL_IPC	0
 
 /* CAN Interrupts
 */
-#define	_CAN1_IPL_ISR	ipl2
+#define	_CAN1_IPL_ISR	IPL2SOFT
 #define	_CAN1_IPL_IPC	2
 #define	_CAN1_SPL_IPC	0
 
-#define	_CAN2_IPL_ISR	ipl2
+#define	_CAN2_IPL_ISR	IPL2SOFT
 #define	_CAN2_IPL_IPC	2
 #define	_CAN2_SPL_IPC	0
 
 /* Ethernet Interrupt
 */
-#define	_ETH_IPL_ISR	ipl2
+#define	_ETH_IPL_ISR	IPL2SOFT
 #define	_ETH_IPL_IPC	2
 #define	_ETH_SPL_IPC	0
 

--- a/hardware/pic32/cores/pic32/Tone.cpp
+++ b/hardware/pic32/cores/pic32/Tone.cpp
@@ -171,7 +171,7 @@ extern "C"
 //*	not done yet
 //************************************************************************
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_TIMER_1_VECTOR),interrupt(_T1_IPL_ISR))) Timer1Handler(void)
+void __attribute__((nomips16,vector(_TIMER_1_VECTOR),interrupt(IPL3SRS))) Timer1Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) Timer1Handler(void)
 #endif

--- a/hardware/pic32/cores/pic32/WInterrupts.c
+++ b/hardware/pic32/cores/pic32/WInterrupts.c
@@ -258,7 +258,7 @@ void detachInterrupt(uint8_t interruptNum)
 //************************************************************************
 // INT0 ISR
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_EXTERNAL_0_VECTOR),interrupt(_INT0_IPL_ISR))) ExtInt0Handler(void)
+void __attribute__((nomips16,vector(_EXTERNAL_0_VECTOR),interrupt(IPL4SRS))) ExtInt0Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) ExtInt0Handler(void)
 #endif
@@ -274,7 +274,7 @@ void __attribute__((interrupt(),nomips16)) ExtInt0Handler(void)
 //************************************************************************
 // INT1 ISR
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_EXTERNAL_1_VECTOR),interrupt(_INT1_IPL_ISR))) ExtInt1Handler(void)
+void __attribute__((nomips16,vector(_EXTERNAL_1_VECTOR),interrupt(IPL4SRS))) ExtInt1Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) ExtInt1Handler(void)
 #endif
@@ -290,7 +290,7 @@ void __attribute__((interrupt(),nomips16)) ExtInt1Handler(void)
 //************************************************************************
 // INT2 ISR
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_EXTERNAL_2_VECTOR),interrupt(_INT2_IPL_ISR))) ExtInt2Handler(void)
+void __attribute__((nomips16,vector(_EXTERNAL_2_VECTOR),interrupt(IPL4SRS))) ExtInt2Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) ExtInt2Handler(void)
 #endif
@@ -306,7 +306,7 @@ void __attribute__((interrupt(),nomips16)) ExtInt2Handler(void)
 //************************************************************************
 // INT3 ISR
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_EXTERNAL_3_VECTOR),interrupt(_INT3_IPL_ISR))) ExtInt3Handler(void)
+void __attribute__((nomips16,vector(_EXTERNAL_3_VECTOR),interrupt(IPL4SRS))) ExtInt3Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) ExtInt3Handler(void)
 #endif
@@ -322,7 +322,7 @@ void __attribute__((interrupt(),nomips16)) ExtInt3Handler(void)
 //************************************************************************
 // INT4 ISR
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_EXTERNAL_4_VECTOR),interrupt(_INT4_IPL_ISR))) ExtInt4Handler(void)
+void __attribute__((nomips16,vector(_EXTERNAL_4_VECTOR),interrupt(IPL4SRS))) ExtInt4Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) ExtInt4Handler(void)
 #endif

--- a/hardware/pic32/cores/pic32/WSystem.c
+++ b/hardware/pic32/cores/pic32/WSystem.c
@@ -106,9 +106,10 @@ void initIntVector(void)
 
     for(i=0; i<NUM_INT_VECTOR; i++)
     {
-        // If a compiler installed interrupt handler exits, pre-load it
-        // and don't fool with the priority
-        if(*((uint32_t *) pvOrgIntVec) != 0xFFFFFFFF)
+        // If a compiler installed interrupt handler exits, pre-load it with the original handler
+        // However, if a class construtor has already loaded a value in the table, don't replace it
+        // There is now a default ISR handler so this replacement almost always occurs
+        if(*((uint32_t *) pvOrgIntVec) != 0xFFFFFFFF  && _isr_primary_install[i] == (isrFunc) &_GEN_EXCPT_ADDR)
         {
             _isr_primary_install[i] = (isrFunc) pvOrgIntVec;
         }

--- a/hardware/pic32/cores/pic32/p32_defs.h
+++ b/hardware/pic32/cores/pic32/p32_defs.h
@@ -44,6 +44,7 @@
 #if !defined(_P32_DEFS_H)
 #define _P32_DEFS_H
 
+#include <p32xxxx.h>
 #include "cpudefs.h"
 #include <inttypes.h>
 
@@ -56,6 +57,30 @@
 /* ------------------------------------------------------------ */
 /*				Register Declarations							*/
 /* ------------------------------------------------------------ */
+
+typedef union {
+  struct {
+    unsigned r0:1;
+    unsigned r1:1;
+    unsigned r2:1;
+    unsigned r3:1;
+    unsigned r4:1;
+    unsigned r5:1;
+    unsigned r6:1;
+    unsigned r7:1;
+    unsigned r8:1;
+    unsigned r9:1;
+    unsigned r10:1;
+    unsigned r11:1;
+    unsigned r12:1;
+    unsigned r13:1;
+    unsigned r14:1;
+    unsigned r15:1;
+  };
+  struct {
+    unsigned w:32;
+  };
+} __REGbits_t;
 
 /* This structure describes the register layout of the primary
 ** register, set, clear, and invert registers associated with
@@ -83,31 +108,151 @@ typedef struct {
 */
 #if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
 typedef struct {
-	volatile p32_regset ansel;
-	volatile p32_regset	tris;
-	volatile p32_regset	port;
-	volatile p32_regset	lat;
-	volatile p32_regset	odc;
-	volatile p32_regset cnpu;
-	volatile p32_regset cnpd;
+    union
+    {
+	    volatile p32_regset ansel;
+        struct
+        {
+            volatile __REGbits_t ANSELxbits;
+            volatile __REGbits_t ANSELxCLR;
+            volatile __REGbits_t ANSELxSET;
+            volatile __REGbits_t ANSELxINV;
+        };
+    };
+    union
+    {
+	    volatile p32_regset	tris;
+        struct
+        {
+            volatile __REGbits_t TRISxbits;
+            volatile __REGbits_t TRISxCLR;
+            volatile __REGbits_t TRISxSET;
+            volatile __REGbits_t TRISxINV;
+        };
+    };
+    union
+    {
+	    volatile p32_regset	port;
+        struct
+        {
+            volatile __REGbits_t PORTxbits;
+            volatile __REGbits_t PORTxCLR;
+            volatile __REGbits_t PORTxSET;
+            volatile __REGbits_t PORTxINV;
+        };
+    };
+    union
+    {
+	    volatile p32_regset	lat;
+        struct
+        {
+            volatile __REGbits_t LATxbits;
+            volatile __REGbits_t LATxCLR;
+            volatile __REGbits_t LATxSET;
+            volatile __REGbits_t LATxINV;
+        };
+    };
+    union
+    {
+	    volatile p32_regset	odc;
+        struct
+        {
+            volatile __REGbits_t ODCxbits;
+            volatile __REGbits_t ODCxCLR;
+            volatile __REGbits_t ODCxSET;
+            volatile __REGbits_t ODCxINV;
+        };
+    };
+    union
+    {
+	    volatile p32_regset cnpu;
+        struct
+        {
+            volatile __REGbits_t CNPUxbits;
+            volatile __REGbits_t CNPUxCLR;
+            volatile __REGbits_t CNPUxSET;
+            volatile __REGbits_t CNPUxINV;
+       };
+    };
+
+    union
+    {
+	    volatile p32_regset cnpd;
+        struct
+        {
+            volatile __REGbits_t CNPDxbits;
+            volatile __REGbits_t CNPDxCLR;
+            volatile __REGbits_t CNPDxSET;
+            volatile __REGbits_t CNPDxINV;
+        };
+    };
+
 	volatile p32_regset cncon;
 	volatile p32_regset cnen;
 	volatile p32_regset cnstat;
 } p32_ioport;
 #else
 typedef struct {
-	volatile p32_regset	tris;
-	volatile p32_regset	port;
-	volatile p32_regset	lat;
-	volatile p32_regset	odc;
+    union
+    {
+	    volatile p32_regset	tris;
+        struct
+        {
+            volatile __REGbits_t TRISxbits;
+            volatile __REGbits_t TRISxCLR;
+            volatile __REGbits_t TRISxSET;
+            volatile __REGbits_t TRISxINV;
+        };
+    };
+    union
+    {
+	    volatile p32_regset	port;
+        struct
+        {
+            volatile __REGbits_t PORTxbits;
+            volatile __REGbits_t PORTxCLR;
+            volatile __REGbits_t PORTxSET;
+            volatile __REGbits_t PORTxINV;
+        };
+    };
+    union
+    {
+	    volatile p32_regset	lat;
+        struct
+        {
+            volatile __REGbits_t LATxbits;
+            volatile __REGbits_t LATxCLR;
+            volatile __REGbits_t LATxSET;
+            volatile __REGbits_t LATxINV;
+        };
+    };
+    union
+    {
+	    volatile p32_regset	odc;
+        struct
+        {
+            volatile __REGbits_t ODCxbits;
+            volatile __REGbits_t ODCxCLR;
+            volatile __REGbits_t ODCxSET;
+            volatile __REGbits_t ODCxINV;
+        };
+    };
 } p32_ioport;
 #endif
 
 /* This structure defines the registers for a PIC32 UART.
 */
 typedef struct {
-	volatile p32_regset	uxMode;
-	volatile p32_regset	uxSta;
+    union
+    {
+        volatile __U1MODEbits_t uartMode;
+	    volatile p32_regset	    uxMode;
+    };
+    union
+    {
+	    volatile __U1STAbits_t	uartSta;
+	    volatile p32_regset	    uxSta;
+    };
 	volatile p32_regbuf	uxTx;
 	volatile p32_regbuf	uxRx;
 	volatile p32_regset	uxBrg;
@@ -128,8 +273,16 @@ typedef struct {
 /* Structure for the registers of a PIC32 SPI controller
 */
 typedef struct {
-	volatile p32_regset sxCon;
-	volatile p32_regset sxStat;
+    union
+    {
+        volatile __SPI2CONbits_t    spiCon;
+	    volatile p32_regset         sxCon;
+    };
+    union
+    {
+	    volatile __SPI2STATbits_t   spiStat;
+	    volatile p32_regset         sxStat;
+    };
 	volatile p32_regbuf sxBuf;
 	volatile p32_regset sxBrg;
 } p32_spi;
@@ -153,8 +306,16 @@ typedef struct {
 /* This structure defines the registers for a PIC32 I2C port.
 */
 typedef struct {
-	volatile p32_regset	ixCon;
-	volatile p32_regset ixStat;
+    union
+    {
+        volatile __I2C1CONbits_t    i2cCon;
+	    volatile p32_regset	        ixCon;
+    };
+    union
+    {
+        volatile __I2C1STATbits_t   i2cStat;
+	    volatile p32_regset         ixStat;
+    };
 	volatile p32_regset ixAdd;
 	volatile p32_regset ixMsk;
 	volatile p32_regset ixBrg;
@@ -643,6 +804,7 @@ typedef uint32_t p32_ppsin;
 
 
 #elif defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
+
 
 /* The PPS pins and peripheral functions are divided up into four sets.
 ** In some cases, the sets are disjoint, and in other cases there is

--- a/hardware/pic32/cores/pic32/wiring.c
+++ b/hardware/pic32/cores/pic32/wiring.c
@@ -215,11 +215,17 @@ void init()
 	//*	as per Al.Rodriguez@microchip.com, Jan 7, 2011
 	//*	Disable the JTAG interface.
 #if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
-	CFGCONbits.JTAGEN = 0;
-	//CFGCONbits.TDOEN = 0;
-	//OSCCONbits.SOSCEN = 0;
+    #if defined(_JTAG) && (_JTAG == 1)
+	    CFGCONbits.JTAGEN = 1;
+    #else
+	    CFGCONbits.JTAGEN = 0;
+    #endif
 #else
-	DDPCONbits.JTAGEN	=	0;
+    #if defined(_JTAG) && (_JTAG == 1)
+	    DDPCONbits.JTAGEN	=	0;
+    #else
+	    DDPCONbits.JTAGEN	=	0;
+    #endif
 #endif
 
 #if (OPT_BOARD_INIT != 0)
@@ -709,7 +715,7 @@ uint32_t millisecondCoreTimerService(uint32_t curTime)
 **
 */
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16, vector(_CORE_TIMER_VECTOR),interrupt(_CT_IPL_ISR))) CoreTimerHandler(void)
+void __attribute__((nomips16, vector(_CORE_TIMER_VECTOR),interrupt(IPL7SRS))) CoreTimerHandler(void)
 #else
 void __attribute__((interrupt(),nomips16)) CoreTimerHandler(void)
 #endif

--- a/hardware/pic32/cores/pic32/wiring_private.h
+++ b/hardware/pic32/cores/pic32/wiring_private.h
@@ -69,7 +69,7 @@
 
 		#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 			#define EXTERNAL_NUM_INTERRUPTS 8
-		#elif defined(__PIC32MX__)
+		#elif defined(__PIC32MX__) || defined(__PIC32MZXX__)
 			#define EXTERNAL_NUM_INTERRUPTS 5
 		#else
 			#define EXTERNAL_NUM_INTERRUPTS 2

--- a/hardware/pic32/libraries/Servo/utility/int.c
+++ b/hardware/pic32/libraries/Servo/utility/int.c
@@ -48,7 +48,7 @@
 //	more generic.
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_TIMER_3_VECTOR),interrupt(_T3_IPL_ISR))) T3_IntHandler(void)
+void __attribute__((nomips16,vector(_TIMER_3_VECTOR),interrupt(IPL4SRS))) T3_IntHandler(void)
 #else
 void __attribute__((interrupt(),nomips16)) T3_IntHandler (void)
 #endif
@@ -59,7 +59,7 @@ void __attribute__((interrupt(),nomips16)) T3_IntHandler (void)
 
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_TIMER_3_VECTOR),interrupt(_T3_IPL_ISR))) T3_IntHandler(void)
+void __attribute__((nomips16,vector(_TIMER_4_VECTOR),interrupt(IPL4SRS))) T4_IntHandler(void)
 #else
 void __attribute__((interrupt(),nomips16)) T4_IntHandler (void)
 #endif
@@ -69,7 +69,7 @@ void __attribute__((interrupt(),nomips16)) T4_IntHandler (void)
 }
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_TIMER_3_VECTOR),interrupt(_T3_IPL_ISR))) T3_IntHandler(void)
+void __attribute__((nomips16,vector(_TIMER_5_VECTOR),interrupt(IPL4SRS))) T5_IntHandler(void)
 #else
 void __attribute__((interrupt(),nomips16)) T5_IntHandler (void)
 #endif
@@ -80,19 +80,30 @@ void __attribute__((interrupt(),nomips16)) T5_IntHandler (void)
 
 void initISR(int timer)
 {
+
+#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
+    // 40000000 / 32 / 25000 = 50 => 20ms
+    uint8_t     tckps   = 0b101;    // set prescalar 1:32
+    uint16_t    prx     = 0x61A8;   // 25000
+#elif defined(__PIC32MZXX__)
+    // 200000000 / PB3(usually == 2) / 64 / 31250 = 50 => 20ms
+    uint8_t     tckps   = 0b110;    // set prescalar 1:64
+    uint16_t    prx     = F_CPU / (PB3DIV + 1) / 64 / 50;   
+#else
+    // 80000000 / 64 / 25000 = 50 => 20ms
+    uint8_t     tckps   = 0b110;    // set prescalar 1:64
+    uint16_t    prx     = 0x61A8;   // 25000
+#endif
+
     if(timer == TIMER3)
     {
         // set the vector up
         setIntVector(_TIMER_3_VECTOR, T3_IntHandler);
 
          //timer 3 set clock period 20ms
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
-        T3CONbits.TCKPS = 0b101; // set prescalar 1:32
-#else
-        T3CONbits.TCKPS = 0b110; // set prescalar 1:64
-#endif
+        T3CONbits.TCKPS = tckps; 
         TMR3 = 0;
-        PR3 = 0x61A8;        
+        PR3 = prx;        
            
 	    IFS0bits.T3IF = 0;// Clear the T3 interrupt flag 
 	    IEC0bits.T3IE = 1;// Enable T3 interrupt 
@@ -108,13 +119,9 @@ void initISR(int timer)
         setIntVector(_TIMER_4_VECTOR, T4_IntHandler);
  
         //timer 4 set clock period 20ms 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
-        T4CONbits.TCKPS = 0b101; // set prescalar 1:32
-#else
-        T4CONbits.TCKPS = 0b110; // set prescalar 1:64
-#endif
+        T4CONbits.TCKPS = tckps; 
         TMR4 = 0;
-        PR4 = 0x61A8;        
+        PR4 = prx;        
            
 	    IFS0bits.T4IF = 0;// Clear the T4 interrupt flag 
 	    IEC0bits.T4IE = 1;// Enable T4 interrupt 
@@ -130,13 +137,9 @@ void initISR(int timer)
         setIntVector(_TIMER_5_VECTOR, T5_IntHandler);
 
         //timer 5 set clock period 20ms 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
-        T5CONbits.TCKPS = 0b101; // set prescalar 1:32
-#else
-        T5CONbits.TCKPS = 0b110; // set prescalar 1:64
-#endif
+        T5CONbits.TCKPS = tckps; 
         TMR5 = 0;
-        PR5 = 0x61A8;        
+        PR5 = prx;        
            
 	    IFS0bits.T5IF = 0;// Clear the T5 interrupt flag 
 	    IEC0bits.T5IE = 1;// Enable T5 interrupt 

--- a/hardware/pic32/libraries/Wire/DTWI.cpp
+++ b/hardware/pic32/libraries/Wire/DTWI.cpp
@@ -1,0 +1,1554 @@
+/************************************************************************/
+/*                                                                      */
+/*    DTWI.cpp                                                          */
+/*                                                                      */
+/*    DTWI  implemenation                                                */
+/*                                                                      */
+/************************************************************************/
+/*    Author:     Keith Vogel                                           */
+/*    Copyright 2014, Digilent Inc.                                     */
+/************************************************************************/
+/* 
+*
+* Copyright (c) 2013-2014, Digilent <www.digilentinc.com>
+* Contact Digilent for the latest version.
+*
+* This program is free software; distributed under the terms of 
+* BSD 3-clause license ("Revised BSD License", "New BSD License", or "Modified BSD License")
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1.    Redistributions of source code must retain the above copyright notice, this
+*        list of conditions and the following disclaimer.
+* 2.    Redistributions in binary form must reproduce the above copyright notice,
+*        this list of conditions and the following disclaimer in the documentation
+*        and/or other materials provided with the distribution.
+* 3.    Neither the name(s) of the above-listed copyright holder(s) nor the names
+*        of its contributors may be used to endorse or promote products derived
+*        from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+* OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+* OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/************************************************************************/
+/*  Revision History:                                                   */
+/*    8/4/2014(KeithV): Created                                         */
+/************************************************************************/
+#include <DTWI.h>
+
+#define I2C_BUS_COLLISION_EVENT     0b001
+#define I2C_SLAVE_EVENT             0b010
+#define I2C_MASTER_EVENT            0b100
+
+#define shiftBus                    0
+#define shiftSlave                  1
+#define shiftMaster                 2
+
+//#define read_ra(dest) __asm__ __volatile__("move %0,$ra" : "=r" (dest))
+//#define read_ra(dest) __asm__ __volatile__("LW %0,28($sp)" : "=r" (dest))
+#define read_count(dest) __asm__ __volatile__("mfc0 %0,$9" : "=r" (dest))
+#define CORETIMER_TICKS_PER_MICROSECOND		(F_CPU / 2 / 1000000UL)
+
+// this is used for MZ parts
+#define pISROffset  ((uint32_t *) &OFF000)
+
+/************************************************************************/
+/************************************************************************/
+/*                      CONSTRUCTORS                                    */
+/************************************************************************/
+/************************************************************************/
+
+DTWI::DTWI(p32_i2c * ptwiC, uint8_t irqBusC, uint8_t vecC, uint8_t iplC, uint8_t splC, uint8_t pinSCLC, uint8_t pinSDAC)
+{
+    int             bnIRQ   = (irqBusC % 32);                           // IE and IF bit locations
+    uint32_t        bmI2C   = 0;
+
+    // make sure we don't assert a stop condition
+    fStop       = false;
+    fMasterMode = false;    // slave mode is sort of always on
+
+    // clear IO buffers
+    iReadNext   = 0;
+    iReadLast   = 0;
+    iWriteNext  = 0;
+    iWriteLast  = 0;
+    addr        = addrGenCall;
+    iSession      = 0;
+
+    // passed in values
+    ptwi            = ptwiC;
+    ptwi->ixCon.reg = 0;            // make sure the I2C device is OFF
+
+    irqBus          = irqBusC;
+    vec             = vecC;
+    ipl             = iplC;
+    spl             = splC;
+    pinSCL          = pinSCLC;
+    pinSDA          = pinSDAC;
+
+    // set priority and sub priority
+    setIntPriority(vec, ipl, spl);
+
+    // MZ has 2 more vectors to worry about
+#if defined(__PIC32MZXX__)
+
+    // the MZ part works off of offset tables
+    // We are given the BUS VEC, and we must fill in the 
+    // the SLAVE and MASTER VECs as well
+    pISROffset[vec+1] = pISROffset[vec];
+    pISROffset[vec+2] = pISROffset[vec];
+
+    // and set the priorities for the other 2 vectors.
+    setIntPriority(vec+1, ipl, spl);
+    setIntPriority(vec+2, ipl, spl);
+#endif
+
+    // calculated values
+    pregIfs = (((p32_regset *)&IFS0) + (irqBus / 32)); 
+    pregIec = (((p32_regset *)&IEC0) + (irqBus / 32));
+
+    bitB = (I2C_BUS_COLLISION_EVENT) << bnIRQ;
+    bitMASK = 0;
+
+    bmI2C = bitB | (bitB << shiftSlave) | (bitB << shiftMaster);
+
+    // Disable the interrupt because we don't want to call this until after the begin()
+	pregIec->clr = bmI2C;
+
+    // Clear the interrupt flags
+	pregIfs->clr = bmI2C;
+
+    // init the state machine state
+    curState  = I2C_IDLE; 
+
+    // put a default of 100KHz
+    // use F_CPU because __PIC32_pbClk is not set up yet
+    // as constructor run before MPIDE Init; however, this would be the correct
+    // value at this point as noone has the chance to change the clock freq
+    // later we can use __PIC32_pbClk; which is used in masterStart
+    ptwi->ixBrg.reg = (F_CPU/FQ100KHz/2) - (((F_CPU / 10000000) * 26) / 25) - 2;
+
+    // put the slave general call address
+    ptwi->ixAdd.reg = addrGenCall;
+
+    ptwi->ixCon.reg   = 0;      // turn everything OFF
+    ptwi->ixStat.reg  = 0;      // clear the status bits as well
+}
+
+/************************************************************************/
+/************************************************************************/
+/*                      Generic Methods                                 */
+/************************************************************************/
+/************************************************************************/
+
+/***    DTWI::I2C_STATUS getStatus(void)
+ *
+ *    Parameters:
+ *          None
+ *              
+ *    Return Values:
+ *          DTWI::I2C_STATUS
+ *              fRead:  True if currently reading from the bus, 
+ *                          This is from the device's perspective
+ *                          So fRead == true for a slave, means it is a Master write
+ *              fWrite: True if currently writing to the bus, 
+ *                          This is from the device's perspective
+ *                          So fWrite == true for a slave, means it is a Master read
+ *              fNacking: True if all reads are being NAK'ed
+ *              fBusError: True if a bus error occured. You must stopMaster/Slave to recover
+ *              fSlave:    True if a beginSlave was called and the contoller is in Slave mode
+ *              fMaster:   True if a beginMaster was called and the controller is in Master mode
+ *              fMyBus:     True if you are the owner of the bus
+ *              fBusInUse:  True if there is a start condition on the bus, you may or may not be the owener of the bus
+ *              fGenCall:   True if you are currently servicing a General Call transaction 
+ *              addr:       The current addr being serviced on the bus
+ *
+ *    Description: 
+ *
+ *      Notes:
+ * ------------------------------------------------------------ */
+DTWI::I2C_STATUS DTWI::getStatus(void)
+{
+    I2C_STATUS          status;
+
+    I2C_STATE volatile  curStateFreeze  = curState;
+    bool volatile       fBusInUse       = ptwi->i2cStat.S;
+    bool volatile       fBusError       = curStateFreeze == I2C_BUS_ERROR || ptwi->i2cStat.BCL;
+    bool volatile       fI2COn          = ptwi->i2cCon.ON;
+    bool                fMyBus          = fI2COn && !fBusError && fBusInUse && curStateFreeze != I2C_IDLE;
+
+    // this is a very nasty condition with the Microchip controller. The controller actually does NOT
+    // give you an interrupt on a stop condition; on some controller. So we could be looking at status
+    // see a stop condition (!S) yet our state machine may not know it. So to keep the state machine and
+    // and status in sync, if we notice we lost the bus, yet did not get an interrupt... put ourselves back to the
+    // the idle state
+    // even worse... the MZ does not put a proper stop condition out, it does a stop than start; we will miss the
+    // the stop as no interrupt is fired, but then we jsut see the start again, but that just looks like the old start
+    // but if we are polling for a stop... put our state machine in sync with our polling.
+    if(!fMyBus && curStateFreeze != I2C_BUS_ERROR && curStateFreeze != I2C_IDLE)
+    {
+        forceIdleState();
+    }
+
+    status.addr         = addr;
+    status.iSession     = iSession;
+    status.fGenCall     = fMyBus && (status.addr == addrGenCall) && ptwi->i2cCon.GCEN;
+    status.fNacking     = !fMyBus || cbToNAK == 0;
+
+    status.fRead        = fMyBus && (curStateFreeze == I2C_DATA_READ || curStateFreeze == I2C_ACK);
+    status.fWrite       = fMyBus && curStateFreeze == I2C_DATA_WRITE;
+    status.fBusError    = fBusError;
+    status.fSlave       = fI2COn && !fMasterMode;
+    status.fMaster      = fI2COn && fMasterMode;
+    status.fMyBus       = fMyBus;
+    status.fBusInUse    = fBusInUse;
+
+    return(status);
+}
+
+/***    uint32_t write(const byte * pb, uint32_t cb)
+ *
+ *    Parameters:
+ *          pb: pointer to a byte stream to write to the bus
+ *          cb: the number of bytes to write out
+ *              
+ *    Return Values:
+ *          The number of bytes queued for transmit. This may be smaller than cb. 
+ *
+ *    Description: 
+ *         Writes as many bytes as possible to the the transmit buffer and is queued for transmission. The transmit buffer
+ *          is small, so not all bytes may be taken. write() should be continually called until all bytes have been accepted.
+ *          code something link.....  cbWritten += write(&rgb[cbWritten], cbTotal-cbWritten); should be called until cbWritten == cbTotal.
+ *          Writing out a large buffer could take some time to do.
+ *
+ *          You can call write() at any time, even before you are writting to the bus; this call only loads the transmit buffer and as long as the buffer
+ *          is not full it will take some bytes. However, once full, no more bytes will be accepted until bytes are transmitted. The bus clock will be held
+ *          low if the transmit buffer is empty.
+ *
+ *      Notes:
+ * ------------------------------------------------------------ */
+uint32_t DTWI::write(const byte * pb, uint32_t cb)
+{
+    uint8_t iNext       = iWriteNext;   // freeze this, interrupt routine updates this  
+    uint8_t cbCopy1     = 0;
+    uint8_t cbCopy2     = 0;
+    bool    fPrime      = transmitting() == 0;
+
+    if(iWriteLast < sizeof(rgbOut))
+    {
+        cbCopy1 = sizeof(rgbOut) - iWriteLast;
+        cbCopy2 = iNext;
+    }
+    else
+    {
+        cbCopy1 = sizeof(rgbOut) - (iWriteLast - iNext);
+    }
+
+    // get max copy sizes
+    cbCopy1 = min(cb, cbCopy1);
+    cb -= cbCopy1;
+    cbCopy2 = min(cb, cbCopy2);
+
+    if((cbCopy1 + cbCopy2) == 0)
+    {
+        return(0);
+    }
+
+    // do the copies
+    if(cbCopy1 > 0)
+    {
+        memcpy(&rgbOut[iWriteLast % sizeof(rgbOut)], pb, cbCopy1);
+        pb += cbCopy1;
+    }
+
+    if(cbCopy2 > 0)
+    {
+        memcpy(rgbOut, pb, cbCopy2);
+    }
+
+    // How many bytes actually transferred
+    cbCopy1 += cbCopy2;
+
+    // we are going to modify some interrupt variables
+    pregIec->clr = bitMASK; // turn off interrupts
+    if(iWriteNext >= sizeof(rgbOut))
+    {
+        iWriteNext -= sizeof(rgbOut);
+        iWriteLast -= sizeof(rgbOut);
+    }
+    iWriteLast += cbCopy1;
+    pregIec->set = bitMASK; // turn interrutps back on
+
+    // kick off the state machine and get things writing
+    if(fPrime && cbCopy1 > 0)
+    {
+        primeMasterSlave();
+    }
+
+    return(cbCopy1);
+}
+
+/***    void DTWI::purge(void)
+ *
+ *    Parameters:
+ *          None
+  *              
+ *    Return Values:
+ *          none
+ *
+ *    Description: 
+ *      Purges the transmit buffer and removes all unwritten bytes from the buffer
+ *    
+ * ------------------------------------------------------------ */
+void DTWI::abort(void)
+{
+    if(transmitting())
+    {
+        // we are going to modify some interrupt variables
+        pregIec->clr = bitMASK; // turn off interrupts
+        iWriteNext = iWriteLast;
+        if(iWriteNext >= sizeof(rgbOut))
+        {
+            iWriteNext -= sizeof(rgbOut);
+            iWriteLast -= sizeof(rgbOut);
+        }
+        pregIec->set = bitMASK; // turn interrutps back on
+    }
+}
+
+/***    uint32_t read(byte * pb, uint32_t cbMax)
+ *
+ *    Parameters:
+ *          pb: a pointer to a buffer to recieve bytes read
+ *          cbMax: The maximum size of the buffer pointed to by pb
+ *              
+ *    Return Values:
+ *          The number of bytes read into pb
+ *
+ *    Description: 
+ *      This can be called at anytime and just gets data out of the recieve buffer. It is even possible that
+ *      the data in the recieve buffer was collected from multilple masters. The data is in the order recieved.
+ *    
+ * ------------------------------------------------------------ */
+uint32_t DTWI::read(byte * pb, uint32_t cbMax)
+{
+    uint8_t iLast = iReadLast;  // freeze this as the interrupt routine modifies it
+    uint8_t cbCopy1 = 0;
+    uint8_t cbCopy2 = 0;
+    bool    fPrime  = available() == sizeof(rgbIn);
+
+    if(iLast > sizeof(rgbIn))
+    {
+        cbCopy1 = sizeof(rgbIn) - iReadNext;
+        cbCopy2 = iLast - sizeof(rgbIn);
+    }
+    else
+    {
+        cbCopy1 = iLast - iReadNext;
+    }
+
+    // get max copy sizes
+    cbCopy1 = min(cbMax, cbCopy1);
+    cbMax -= cbCopy1;
+    cbCopy2 = min(cbMax, cbCopy2);
+
+    if((cbCopy1 + cbCopy2) == 0)
+    {
+        return(0);
+    }
+
+    // do the copies
+    if(cbCopy1 > 0)
+    {
+        memcpy(pb, &rgbIn[iReadNext % sizeof(rgbIn)], cbCopy1);
+        pb += cbCopy1;
+    }
+
+    if(cbCopy2 > 0)
+    {
+        memcpy(pb, rgbIn, cbCopy2);
+    }
+
+    // How many bytes actually transferred
+    cbCopy1 += cbCopy2;
+
+    // we are going to modify some interrupt variables
+    pregIec->clr = bitMASK; // turn off interrupts
+    iReadNext += cbCopy1;
+    if(iReadNext >= sizeof(rgbIn))
+    {
+        iReadNext -= sizeof(rgbIn);
+        iReadLast -= sizeof(rgbIn);
+    }
+    pregIec->set = bitMASK; // turn interrutps back on
+
+    // kick off the state machine and get things reading
+    if(fPrime && available() < sizeof(rgbIn))
+    {
+        primeMasterSlave();
+    }
+
+    return(cbCopy1);
+}
+
+/***    void DTWI::discard(void)
+ *
+ *    Parameters:
+ *          None
+  *              
+ *    Return Values:
+ *          none
+ *
+ *    Description: 
+ *      Flushes the read buffer and removes all unread bytes from the buffer
+ *    
+ * ------------------------------------------------------------ */
+void DTWI::discard(void)
+{
+    while(available())
+    {
+        // we are going to modify some interrupt variables
+        pregIec->clr = bitMASK; // turn off interrupts
+        iReadNext = iReadLast;
+        if(iReadNext >= sizeof(rgbIn))
+        {
+            iReadNext -= sizeof(rgbIn);
+            iReadLast -= sizeof(rgbIn);
+        }
+        pregIec->set = bitMASK; // turn interrutps back on
+
+        // kick off the state machine and get things reading
+        primeMasterSlave();
+    }
+}
+
+/***    bool DTWI::setNAK(uint32_t cbToNak)
+ *
+ *    Parameters:
+ *          cbToNak: The number of bytes to read before a Nak is issues, stoping any more 
+ *          data to come in.
+ *              
+ *    Return Values:
+ *          True if it was possible to update the Nak location, false if it was impossible to do
+ *
+ *    Description: 
+ *          cbToNak is based off of what has been currently read by the applicaiton; not counting
+ *          what is in the recieve buffer. So it is possible for the application to try and set a Nak
+ *          location too low as the byte has already been recieved and is sitting in the receive buffer. Under this
+ *          a false will be returned as the Nak can't be set.
+ *    
+ * ------------------------------------------------------------ */
+bool DTWI::setNAK(uint32_t cbToNakT)
+{
+    bool fRet = false;
+
+    pregIec->clr = bitMASK; // turn off interrupts
+
+    // everything that has come in, we have already ACKed
+    // we need 1 more byte to come into NAK, so cbToNakT must be
+    // greater than what has already come in for this to work
+    if((fRet = (cbToNakT > available())))
+    {
+        // cbToNak must be > 0
+        cbToNAK = cbToNakT - available();
+    }
+    pregIec->set = bitMASK; // turn on interrupts
+
+    return(fRet);
+}
+
+/***    primeMasterSlave
+ *
+ *    Parameters:
+ *          None
+ *              
+ *    Return Values:
+ *          None
+ *
+ *    Description: 
+ *          Allows the master state machine to be called from
+ *          the application safely. This is used by read() and write() to
+ *          bump the state machine to start transmitting or recieving data.
+ *    
+ * ------------------------------------------------------------ */
+void DTWI::primeMasterSlave(void)
+{
+
+    // Only do something if it is my bus
+    if(!getStatus().fMyBus)
+    {                               
+        return;
+    }
+
+    // master mode, prime the master
+    else if(fMasterMode)
+    {
+        pregIec->clr = (bitB << shiftMaster);
+        pregIfs->set = (bitB << shiftMaster);
+        pregIec->set = (bitB << shiftMaster);
+    }
+
+    // slave mode, prime the slave
+    else
+    {
+        pregIec->clr = (bitB << shiftSlave);
+        pregIfs->set = (bitB << shiftSlave);
+        pregIec->set = (bitB << shiftSlave);
+    }
+}
+
+/***    void forceIdleState(void)
+ *
+ *    Parameters:
+ *          None
+ *              
+ *    Return Values:
+ *          None
+ *
+ *    Description: 
+ *      This put the controller and state machine back to the Idle state
+ *      to either the Master or Slave state machines
+ *    
+ * ------------------------------------------------------------ */
+void DTWI::forceIdleState(void)
+{
+        uint32_t tStart     = 0;
+        uint32_t tCur       = 0;
+        uint32_t IEFlags    = pregIec->reg & bitMASK;
+
+        // disable interrupts
+        pregIec->clr    = bitMASK;
+
+        // if we are going to turn off the controller
+        // nothing in the interrupt flags is going to make sense
+        // just clear them
+        pregIfs->clr    = bitMASK;
+
+        // go back to the idle state
+        curState        = I2C_IDLE;
+
+        // toggle the controller.... very ugly!
+        ptwi->i2cCon.ON = 0;
+
+        // let the controller settle
+        read_count(tStart);
+        do {
+            read_count(tCur);
+        } while(tCur - tStart < CORETIMER_TICKS_PER_MICROSECOND);
+
+        // turn the controller back on
+        ptwi->i2cCon.ON = 1;
+
+        // let the controller settle
+        read_count(tStart);
+        do {
+            read_count(tCur);
+        } while(tCur - tStart < CORETIMER_TICKS_PER_MICROSECOND);
+
+        // go back to where we were with interrupts
+        pregIec->set    = IEFlags;
+}
+
+/************************************************************************/
+/************************************************************************/
+/*                      MASTER MODE                                     */
+/************************************************************************/
+/************************************************************************/
+
+/***    bool beginMaster(uint8_t addrSlave)
+ *
+ *    Parameters:
+ *          feqI2C: The freq to run the clock at. By default this is 100KHz
+ *              
+ *    Return Values:
+ *          True if the begin successfully started, false if already in slave mode
+ *          or the I2C controller is already in use
+ *
+ *    Description: 
+ *          Puts the I2C controller in Master mode.
+ *    
+ * ------------------------------------------------------------ */
+bool DTWI::beginMaster(I2C_FREQ feqI2C)
+{
+    // already in master mode
+    if(fMasterMode)
+    {
+        return(true);
+    }
+    // check that it is one of the allowed frequences
+    // the bus must be in a idle state
+    else if(ptwi->i2cCon.ON || !(feqI2C == FQ100KHz || feqI2C == FQ400KHz || feqI2C == FQ1MHz) || ptwi->i2cStat.S)
+    {
+        return(false);
+    }
+
+    // turn off interrupts
+    pregIec->clr = bitB | (bitB << shiftSlave) | (bitB << shiftMaster);
+
+    // little known fact, the I2C controller will not automatically
+    // select digital mode on the pin. So if it was used the pins for
+    // the I2C controller will not work. This is particulary true on the MZ
+    pinMode(pinSDA, INPUT);
+    pinMode(pinSCL, INPUT);
+
+    // put the state machine at the idle state
+    curState = I2C_IDLE;
+    iSession = 0;
+
+    // make sure we don't assert a stop condition
+    fStop = false;
+
+    // we are in Master Mode
+    fMasterMode = true;
+
+    // clear all status bits
+    ptwi->ixStat.reg = 0;
+
+    // calculate the BRG and set the frequency of the master
+    // here we can use __PIC32_pbClk as the MPIDE init code has run by now
+    ptwi->ixBrg.reg = (__PIC32_pbClk/feqI2C/2) - (((__PIC32_pbClk / 10000000) * 26) / 25) - 2;
+
+    // enable Master mode interrupts
+    bitMASK = bitB | (bitB << shiftMaster);
+    pregIfs->clr = bitMASK;
+
+    // turn on the I2C controller, if it is not already ON
+    ptwi->i2cCon.ON  = 1; 
+
+    return(true);
+}
+
+/***    endMaster(void)
+ *
+ *    Parameters:
+ *          None
+ *              
+ *    Return Values:
+ *          None
+ *
+ *    Description: 
+ *      Turns off the I2C controller. This is abrupt and will abort any current operation
+ *      stopMaster() or stopSlave() should be successfully called before calling this. However to 
+ *      abort all operations, this can be called at any time.
+ *    
+ * ------------------------------------------------------------ */
+void DTWI::endMaster(void)
+{
+    // if in slave mode, the master is not running
+    if(!fMasterMode)
+    {
+        return;
+    }
+
+    // turn off interrupts
+    pregIec->clr = bitB | (bitB << shiftSlave) | (bitB << shiftMaster);
+    pregIfs->clr = bitB | (bitB << shiftSlave) | (bitB << shiftMaster);
+ 
+    // clear ourselves out of our state
+    bitMASK = 0;
+    ptwi->i2cCon.ON  = 0; 
+
+    // make sure we don't assert a stop condition
+    curState    = I2C_IDLE;
+    fStop       = false;
+    fMasterMode = false;    // slave mode is sort of always on
+    iWriteNext  = 0;
+    iWriteLast  = 0;
+}
+
+/***    bool startMaster(uint8_t addrSlave, uint32_t cbRead, bool fRead)
+ *
+ *    Parameters:
+ *          addrSlave:  The Slave address the Master wishes to talk too.
+ *          cbRead:     How many bytes to read before sending a Nak, this can be changed by setNAK
+ *          fRead:      True if we want to start a read from the slave, false if we want to write to the slave.
+ *              
+ *    Return Values:
+ *          True if we got the bus and the slave responded, False if we did not get the connection with the slave
+ *
+ *    Description: 
+ *      Asserts a START condition on the I2C bus, puts the address out AND sets the R /W bit and enables the I2C interrupts
+ *      startMaster() can be called before stopMaster(); and if done this way while the application own the bus, it will cause a repeated start condition to be asserted on the bus
+ *      If this call fails, someone else may have the bus, or a previous startMaster() may be finishing up writing out the tranmit buffer, continue to call startMaster() until it passes
+ *      however, be careful as if someone else has the bus, this may never return true as the bus never becomes available.
+ *      If the applicaiton currently does not own the bus, and this call fails, the I2C interrupts will be disabled.
+ *      This call is used to implement both  
+ *          startMasterRead   
+ *          startMasterWrite
+ * ------------------------------------------------------------ */
+bool DTWI::startMaster(uint8_t addrSlave, uint32_t cbRead, bool fRead)
+{
+    uint8_t volatile rcvB;  // make volatile so the compiler will actually read the recv buffer and not opt out
+    uint32_t    tCur = 0;
+    uint32_t    tStart = 0;
+
+    // Not in Master mode, or we still have stuff to transmit, or we initiated a stop condition
+    if(!fMasterMode || ptwi->i2cStat.TRSTAT || (ptwi->ixCon.reg & 0b11111))
+    {
+        return(false);
+    }
+
+    // we don't want to take an interrupt right now
+    // we want to manually poll that the addr was accepted
+    pregIec->clr = bitMASK;
+    pregIfs->clr = bitMASK;
+
+    // if we have something in the read buffer, just get it out
+    rcvB = ptwi->ixRcv.reg;
+
+    // clear error flags
+    ptwi->ixStat.reg = 0;
+
+    // If there is a start condition on the bus and we own the bus
+    // we need to do a repeat start
+    if(ptwi->i2cStat.S && curState != I2C_IDLE)
+    {
+        // go back to the idle state
+        curState = I2C_IDLE;
+
+        // the lower 5 bits must be set to zero
+        while(ptwi->ixCon.reg & 0b11111);
+
+        ptwi->i2cCon.RSEN = 1;
+
+        // wait repeat start to complete
+        while(ptwi->i2cCon.RSEN);
+    }
+
+    // if there is no start condition on the bus
+    else if(!ptwi->i2cStat.S)
+    {
+        // force an idle state
+        curState = I2C_IDLE;
+
+        // the lower 5 bits must be set to zero
+        while(ptwi->ixCon.reg & 0b11111);
+
+        // set the start event
+        ptwi->i2cCon.SEN = 1;
+
+        // wait for the start condition to complete
+        while(ptwi->i2cCon.SEN);
+    }
+
+    // someone else has the bus
+    else
+    {
+        return(false);
+    }
+
+    // someone else has the bus, it could be a client had SDA held low
+    if(ptwi->i2cStat.BCL)
+    {
+        return(false);
+    }
+
+    fStop = false;
+
+    // Write out the address and R/W bit
+    ptwi->ixTrn.reg = (addrSlave << 1) | fRead;
+
+    // required settling time on the transmit buffer
+    read_count(tStart);
+    do {
+        read_count(tCur);
+    } while(tCur - tStart < (CORETIMER_TICKS_PER_MICROSECOND / 4));
+
+    // release the stretch so we will transmit the byte
+//    ptwi->i2cCon.SCLREL = 1;
+
+    // quit if we get a bus conflict OR the transmit compiletes
+    // if the TRSTAT get set, we know we got the ACK/NAK
+    while(ptwi->i2cStat.BCL == 0 && ptwi->i2cStat.TRSTAT);
+
+    // got a bus collision; we are done and don't have the bus
+    if(ptwi->i2cStat.BCL)
+    {
+        return(false);
+    }
+
+    // we got the bus, but the address failed to NAK
+    // there is no device so we want to release the bus and get out
+    else if(ptwi->i2cStat.ACKSTAT)
+    {
+        // the lower 5 bits must be set to zero
+        while(ptwi->ixCon.reg & 0b11111);
+        
+        // assert the stop condition
+        ptwi->i2cCon.PEN = 1;
+
+        return(false);
+    }
+
+    // all is good!
+    addr = addrSlave;
+    iSession++;
+
+    // if this is a MASTER READ
+    if(fRead)
+    {
+        // how many bytes to read before the NAK
+        cbToNAK = cbRead;
+
+        // say we are recieving data
+        curState = I2C_DATA_READ;
+
+        // enable recieving data from the slave
+        ptwi->i2cCon.RCEN = 1;
+    }
+
+    // if this is a MASTER WRITE
+    else
+    {
+        // say we are recieving data
+        curState = I2C_DATA_WRITE;
+    }
+
+    // re-enable the interrupts
+    pregIfs->clr = bitMASK;
+    pregIec->set = bitMASK;
+
+    // see if we got the ACK, or NAK or bus collision
+    return(true);
+}
+
+/***    bool stopMaster(void)
+ *
+ *    Parameters:
+ *          None
+ *              
+ *    Return Values:
+ *          True if the a stop condition was asserted on the bus, false if still writing data or
+ *          reading data. If true, the I2C interrupts are disabled. If false, continue calling stopMaster() until it succeeds.
+ *
+ *    Description: 
+ *      Assert a stop condition on the I2C bus
+ *      You may not be done transimitting data, so call this until it succeeds and you know your data went out.
+ * ------------------------------------------------------------ */
+bool DTWI::stopMaster(void)
+{
+
+    // if not in master mode or not enabled, Master is stopped
+    if(!fMasterMode || !ptwi->i2cCon.ON)
+    {
+        return(true);
+    }
+
+    fStop = true;
+
+    // kick off the state machine and get things writing
+    primeMasterSlave();
+
+    // assert the stop condition
+    if(curState == I2C_WAIT)
+    {
+        // put the state machine in the idle state
+        curState = I2C_IDLE;
+
+        // the lower 5 bits must be set to zero
+        while(ptwi->i2cStat.TRSTAT || (ptwi->ixCon.reg & 0b11111));
+
+        // assert the stop condition
+#if defined(__PIC32MZXX__)
+  
+        if(ptwi->i2cStat.ACKSTAT)
+        {
+
+            // assert the stop condition
+            ptwi->i2cCon.PEN = 1;
+        }
+        else
+        {
+            uint32_t        tStart  = 0;
+            uint32_t        tCur    = 0;
+            uint8_t         port    = digitalPinToPort(pinSDA);
+            p32_ioport *	iop     =  (p32_ioport *)portRegisters(port);
+            uint32_t        bit     = digitalPinToBitMask(pinSDA);
+
+            iop->lat.clr  = bit;	// put a zero in the latch		
+            iop->tris.clr = bit;	// make it an output
+
+            // turn off the I2C controller
+            // the low value of the latch will pull
+            // the SDA low (hold it low).
+            ptwi->i2cCon.ON = 0;
+
+            // wait some time
+            read_count(tStart);
+            do {
+                read_count(tCur);
+            } while(tCur - tStart < 5 * CORETIMER_TICKS_PER_MICROSECOND);
+
+            // tri-state the SDA, let the pull up 
+            // resistor pull it up
+            iop->tris.set = bit;	
+
+            // we have to put some time on the stop condtion
+            read_count(tStart);
+            do {
+                read_count(tCur);
+            } while(tCur - tStart < 10 * CORETIMER_TICKS_PER_MICROSECOND);
+
+            // this will clear the controller
+            forceIdleState();
+        }
+
+#else
+        // assert the stop condition
+        ptwi->i2cCon.PEN = 1;
+#endif
+
+    }
+
+    // if the stop condition has completed or bus error; disable interrupts
+    else if(!(ptwi->ixCon.reg & 0b11111) && (curState == I2C_IDLE || curState == I2C_BUS_ERROR))
+    {        
+        // turn off interrupts
+        pregIec->clr    = bitMASK;
+        pregIfs->clr    = bitMASK;
+
+        addr            = addrGenCall;
+        forceIdleState();
+
+        return(true);
+    }
+
+    return(false);
+}
+
+/************************************************************************/
+/************************************************************************/
+/*                      SLAVE  MODE                                     */
+/************************************************************************/
+/************************************************************************/
+
+/***    bool beginSlave(uint8_t addrSlave, bool fGenCall)
+ *
+ *    Parameters:
+ *          addrSlave:  The address to respond to as the slave
+ *          fGenCall:   True if the application wants to respond to the GenCall address as well. by default this is false
+ *              
+ *    Return Values:
+ *          True if the the I2C controller successfully initialized for slave mode. False if already in Master mode or someone else is using the controller.
+ *
+ *    Description:
+ *          Initializes the I2C controller for slave mode. Interrupts are NOT enabled until startSlave() is called.
+ *    
+ * ------------------------------------------------------------ */
+bool DTWI::beginSlave(uint8_t addrSlave, uint32_t cbToNak, bool fGenCall)
+{ 
+    uint8_t volatile rcvB;  // make volatile so the compiler will actually read the recv buffer and not opt out
+
+    // if in master mode, we can't begin the slave
+    if(fMasterMode || ptwi->i2cCon.ON)
+    {
+        return(false);
+    }
+
+    // turn off interrupts
+    pregIec->clr = bitB | (bitB << shiftSlave) | (bitB << shiftMaster);
+
+    // little known fact, the I2C controller will not automatically
+    // select digital mode on the pin. So if it was used the pins for
+    // the I2C controller will not work. This is particulary true on the MZ
+    pinMode(pinSDA, INPUT);
+    pinMode(pinSCL, INPUT);
+
+    // we are in the idle state
+    curState = I2C_IDLE;
+    iSession = 0;
+
+    // set how long until a NAK
+    cbToNAK = cbToNak;
+
+    // get the address we are listening on
+    addr = addrSlave;
+
+    // see if general call is enabled
+    ptwi->i2cCon.GCEN = fGenCall;
+
+    // say we do not want to go into a stop condition
+    fStop = false;
+
+    // put the slave address in
+    ptwi->ixAdd.reg = addrSlave;
+
+    // turn on clk stretching
+    ptwi->i2cCon.STREN   = 1;
+
+    // enable Master mode interrupts
+    bitMASK = bitB | (bitB << shiftSlave);
+
+    // turn on the I2C controller, if it is not already ON
+    ptwi->i2cCon.ON  = 1; 
+
+    // if we have something in the read buffer, just get it out
+    rcvB = ptwi->ixRcv.reg;
+
+    // make sure the clock is released
+    // actually don't because we don't want to accept data
+    // until we can read it from the buffer
+    //ptwi->i2cCon.SCLREL = 1; 
+
+    // clear all status bits
+    ptwi->ixStat.reg = 0;
+
+    // clear interrupt flags
+    pregIfs->clr = bitMASK;
+
+    // turn interrupts on
+    pregIec->set = bitMASK;
+
+    return(true);
+}
+
+/***    bool stopSlave(void)
+ *
+ *    Parameters:
+ *          None
+ *              
+ *    Return Values:
+ *          true if the I2C stops listening on the bus. False if still writing data out. Keep calling this until it passes to ensure
+ *          all data is written to the Master.
+ *
+ *    Description: 
+ *          Turns of the slave controller by disabling the slave interrupts; and reseting the slave state machine
+ *    
+ * ------------------------------------------------------------ */
+bool DTWI::endSlave(bool fForce)
+{
+    if(fMasterMode || !ptwi->i2cCon.ON)
+        return(true);
+
+    // stop after everything is written out
+    fStop = true;
+
+    primeMasterSlave();
+
+    // if we are done.
+    if(fForce || !getStatus().fMyBus)
+    {
+        // turn off all interrupts
+        pregIec->clr = bitB | (bitB << shiftSlave) | (bitB << shiftMaster);
+        pregIfs->clr = bitB | (bitB << shiftSlave) | (bitB << shiftMaster);
+
+        // turn off the controller
+        ptwi->i2cCon.ON  = 0; 
+
+        // clear ourselves out of our state
+        bitMASK = 0;
+ 
+        // make sure we don't assert a stop condition
+        curState    = I2C_IDLE;
+        fStop       = false;
+        fMasterMode = false;    // slave mode is sort of always on
+        iWriteNext  = 0;
+        iWriteLast  = 0;
+        addr        = addrGenCall;
+
+        return(true);
+    }
+
+    return(false);
+}
+
+/************************************************************************/
+/************************************************************************/
+/*                      STATE MACHINE CODE                              */
+/************************************************************************/
+/************************************************************************/
+
+/***    stateMachine
+ *
+ *    Parameters:
+ *          None
+ *              
+ *    Return Values:
+ *          None
+ *
+ *    Description: 
+ *      This is the master interrupt routine for the I2C controller and vectors
+ *      to either the Master or Slave state machines
+ *    
+ * ------------------------------------------------------------ */
+void __attribute__((nomips16)) DTWI::stateMachine(void)
+{
+    uint32_t bitS   = (bitB << shiftSlave);
+    uint32_t bitM   = (bitB << shiftMaster);
+    uint32_t bitBSM = bitB | bitS | bitM;
+     
+    // as long as we have interrupts to process, process them
+    while(pregIfs->reg & bitBSM)
+    {
+        // save the ifs, so we can clear ifs and make sure
+        // we don't miss an interrupt while processing
+        // ints could be coming fast.
+        uint32_t ifs = pregIfs->reg;
+
+        // clear IFS flags to make sure I catch a missed interrupt
+        pregIfs->clr = bitBSM;
+
+        // got an error, go to the idle state.
+        if(ifs & bitB)
+        {
+            // turn off interrupts, we are not to be on the bus
+            pregIec->clr    = bitBSM;
+            curState        = I2C_BUS_ERROR;
+            return;
+        }
+
+        // otherwise a Master or Slave interrupt
+        else
+        {
+            // slave interrupt
+            if(ifs & bitS)
+            {
+                // if we see an address bit, we know we are starting over; this could be a repeated start
+                // We must have the start condition asserted, an address in the recv buffer and it be an address
+                // Or if we see a stop condition, we are idle
+                if(ptwi->i2cStat.P)
+                {
+                    curState = I2C_IDLE;
+                }
+                else if(!ptwi->i2cStat.D_A && ptwi->i2cStat.RBF && ptwi->i2cStat.S)
+                {
+                    curState = I2C_IDLE;
+                }
+
+                slaveMachine();
+            }
+
+            // master interrupt
+            if(ifs & bitM)
+            {
+                // if we see a stop condition, go to the idle state
+                if(!ptwi->i2cStat.S || ptwi->i2cStat.P)
+                {
+                    curState = I2C_IDLE;
+                }
+
+                masterMachine();
+            }
+        }
+    }
+}
+
+/***    masterMachine
+ *
+ *    Parameters:
+ *          None
+ *              
+ *    Return Values:
+ *          None
+ *
+ *    Description: 
+ *          This is the master state machine called by the interrupt service routine
+ *    
+ * ------------------------------------------------------------ */
+void __attribute__((nomips16)) DTWI::masterMachine(void)
+{
+    switch(curState)
+    {
+         case I2C_ACK:
+
+            // if it was a NAK we are done, just wait
+            if(ptwi->i2cStat.ACKSTAT || fStop)
+            {
+                curState = I2C_WAIT;
+            }
+
+            // otherwise initiate for another read
+            // if we have room for another byte, lets recieve it
+            // otherwise we will just halt the clock until we can read
+            // some more data.
+            else if((iReadLast - iReadNext) < sizeof(rgbIn))
+            {
+                // the lower 5 bits must be set to zero
+                while(ptwi->ixCon.reg & 0b11111);
+
+                curState = I2C_DATA_READ;
+                ptwi->i2cCon.RCEN = 1;
+            }
+            break;
+
+        // got a read
+        case I2C_DATA_READ:
+            if(ptwi->i2cStat.RBF)
+            {
+                rgbIn[iReadLast % sizeof(rgbIn)] = ptwi->ixRcv.reg;
+                iReadLast++;
+
+                if(cbToNAK != recvInfinite)
+                {
+                    cbToNAK--;
+                }
+                curState = I2C_ACK;
+         
+                ptwi->i2cCon.ACKDT = (cbToNAK == 0 || fStop);  // /ACK NAK value
+                ptwi->i2cCon.ACKEN = 1;  //send the ACK
+            }
+
+            // we are told to finish
+            else if(fStop)
+            {
+                curState = I2C_WAIT;
+            }
+            break;
+
+        // if we have a write
+        case I2C_DATA_WRITE:
+
+            // only if the transmit engine is idle
+            if(!ptwi->i2cStat.TRSTAT && !ptwi->i2cStat.TBF)
+            {
+                // get a NAK from the other side, or asked to stop by user
+                if(ptwi->i2cStat.ACKSTAT || (fStop && iWriteNext == iWriteLast))
+                {
+                    curState = I2C_WAIT;
+                }
+
+                // otherwise keep writing data out
+                else if(iWriteNext < iWriteLast)
+                {
+                    uint32_t tStart;
+                    uint32_t tCur;
+
+                    ptwi->ixTrn.reg = rgbOut[iWriteNext % sizeof(rgbOut)];
+ 
+                    // we need 250ns (1/4 usec) for setup time
+                    read_count(tStart);
+
+                    // update the next pointer
+                    // it is okay to go beyond the buffer
+                    // because we use the modulo, and the write
+                    // funciton will adjust the index down
+                    iWriteNext++;
+
+                    // required settling time on the transmit buffer
+                    do {
+                        read_count(tCur);
+                    } while(tCur - tStart < (CORETIMER_TICKS_PER_MICROSECOND / 4));
+
+                    // release the stretch so we will transmit the byte
+ //                   ptwi->i2cCon.SCLREL = 1;
+
+                }
+            }
+            break;
+
+        case I2C_WAIT:
+        case I2C_IDLE:
+        case I2C_BUS_ERROR:
+        default:
+            break;
+       
+    }
+}
+
+/***    slaveMachine
+ *
+ *    Parameters:
+ *          None
+ *              
+ *    Return Values:
+ *          None
+ *
+ *    Description: 
+ *          This is the slave state machine called by the interrupt routine.
+ *    
+ * ------------------------------------------------------------ */
+void __attribute__((nomips16)) DTWI::slaveMachine(void)
+{
+    I2C_STATE passState;
+
+    // we must loop because we my need to transmit after the address
+    // so keep looping until the state is repeated
+    do
+    {
+        passState = curState;
+        switch(curState)
+        {
+
+            case I2C_IDLE:
+
+                if(ptwi->i2cStat.RBF)
+                {
+                    // what we are expecting is and address being sent
+                    if(!ptwi->i2cStat.D_A)
+                    {
+                        uint8_t rcvB = ptwi->ixRcv.reg;
+
+                        // save the address away, this might be different than the init addr
+                        // if we enabled the fGenCall, it might be the general call address
+                        // remember to shift off the R/W bit
+                        addr = rcvB >> 1;
+                        iSession++;           // say we saw a start condition
+
+                        // see if this is a Read or Write from the Master perspective
+                        // or Write or Read from the slave perspective
+                        if(ptwi->i2cStat.R_W)
+                        {
+                            curState = I2C_DATA_WRITE;      // Master R, slave W
+                            ptwi->i2cStat.IWCOL = 0;         // clear write collisions
+                        }
+
+                        // we are not excepting data
+                        else if(cbToNAK == 0)
+                        {
+                            curState            = I2C_IDLE; // we are not doing reads
+                            ptwi->i2cStat.I2COV  = 1;        // make it so we NAK
+                        }
+                 
+                        else
+                        {
+                            curState = I2C_DATA_READ;   // Master W, slave R
+                            ptwi->i2cStat.I2COV = 0;     // clear overflow 
+
+                            // not needed on an MX as this is auto released on an address
+                            // read, not so on an MZ. we need to release it
+                            // buffer because
+                            ptwi->i2cCon.SCLREL = 1;     // release the clk stretching 
+                        }
+                    }
+                }
+
+                // I just don't know what this is
+                // in the idle state I need to get an address... or I just don't know what to do with it
+                // Just get rid of it...
+                else
+                {
+                    uint8_t rcvB = ptwi->ixRcv.reg;
+                    ptwi->i2cStat.I2COV = 0;     // clear overflow
+                    ptwi->i2cCon.SCLREL = 1;     // release the clk stretching 
+                }
+
+                break;
+
+            case I2C_DATA_READ:
+                if(ptwi->i2cStat.RBF && iReadLast - iReadNext < sizeof(rgbIn))
+                {
+                    rgbIn[iReadLast % sizeof(rgbIn)] = ptwi->ixRcv.reg;
+                    iReadLast++;
+
+                    if(cbToNAK != recvInfinite && cbToNAK != 0)
+                    {
+                        cbToNAK--;
+                    }
+         
+                    // if we are done reading data, release the clk and go
+                    // to an I2C_WAIT state
+                    if(cbToNAK == 0)
+                    {
+                        curState = I2C_WAIT;        // we are done with the reads
+                    }
+
+                    ptwi->i2cCon.SCLREL = 1;     // release the clk stretching 
+                }
+                break;
+
+            case I2C_DATA_WRITE:
+
+                // get a NAK from the other side
+                // I really don't know what to do because
+                // the master is clocking me, but he asked me to stop
+                // transmitting. So just release the clock and quit
+                if(ptwi->i2cStat.ACKSTAT)
+                {
+                    curState = I2C_IDLE;
+                }
+
+                // normal case, the write register is open
+                else if(!ptwi->i2cStat.TBF)
+                {
+
+                    // we have something to write
+                    if(iWriteNext < iWriteLast)
+                    {
+                        uint32_t tStart;
+                        uint32_t tCur;
+
+                        // load the buffer
+                        ptwi->ixTrn.reg = rgbOut[iWriteNext % sizeof(rgbOut)];
+                        
+                        // we need 250ns (1/4 usec) for setup time
+                        read_count(tStart);
+
+                        // update the next pointer
+                        // it is okay to go beyond the buffer
+                        // because we use the modulo, and the write
+                        // funciton will adjust the index down
+                        iWriteNext++;
+
+                        // required settling time on the transmit buffer
+                        do {
+                            read_count(tCur);
+                        } while(tCur - tStart < (CORETIMER_TICKS_PER_MICROSECOND / 4));
+
+                        // release the stretch so we will transmit the byte
+                        ptwi->i2cCon.SCLREL = 1;
+                    }
+
+                    // if we are to stop
+                    else if(fStop)
+                    {
+                        curState = I2C_WAIT;
+                    }
+                }
+                break;
+
+            case I2C_WAIT:
+                ptwi->i2cStat.I2COV  = 1;    // Cause a NAK
+                ptwi->i2cCon.SCLREL  = 1;    // release the clk
+                curState = I2C_IDLE;
+                break;
+
+            case I2C_BUS_ERROR:
+            default:
+                break;
+        }
+
+    } while(curState != passState);
+}
+
+/************************************************************************/
+/************************************************************************/
+/*                      OBJECTS INSTANCES AND INTERRUPTS                */
+/************************************************************************/
+/************************************************************************/
+
+#ifdef _DTWI0_BASE
+DTWI0 * DTWI0::pDTWI0 = NULL;
+
+// the class methods
+DTWI0::DTWI0() : DTWI(((p32_i2c *) _DTWI0_BASE), _DTWI0_BUS_IRQ, _DTWI0_VECTOR, _DTWI0_IPL, _DTWI0_SPL, _DTWI0_SCL_PIN, _DTWI0_SDA_PIN) 
+{
+    // save the instance away so the interrupt routine can
+    // get back to this instance
+    pDTWI0 = this;
+
+    // set the interrupt vector
+    setIntVector(_DTWI0_VECTOR, IntDtwi0Handler);
+};
+
+// the associated interrupt routine.
+#if defined(__PIC32MZXX__)
+void __attribute__((nomips16,vector(_DTWI0_VECTOR),interrupt(_DTWI0_IPL_ISR))) IntDtwi0Handler(void)
+#else
+void __attribute__((interrupt(),nomips16)) IntDtwi0Handler(void)
+#endif
+{
+    DTWI0::pDTWI0->stateMachine();
+}
+#endif
+
+#ifdef _DTWI1_BASE
+DTWI1 * DTWI1::pDTWI1 = NULL;
+
+// the class methods
+DTWI1::DTWI1() : DTWI(((p32_i2c *) _DTWI1_BASE), _DTWI1_BUS_IRQ, _DTWI1_VECTOR, _DTWI1_IPL, _DTWI1_SPL, _DTWI1_SCL_PIN, _DTWI1_SDA_PIN) 
+{
+    // save the instance away so the interrupt routine can
+    // get back to this instance
+    pDTWI1 = this;
+
+    // set the interrupt vector
+    setIntVector(_DTWI1_VECTOR, IntDtwi1Handler);
+};
+
+// the associated interrupt routine.
+#if defined(__PIC32MZXX__)
+void __attribute__((nomips16,vector(_DTWI1_VECTOR),interrupt(_DTWI1_IPL_ISR))) IntDtwi1Handler(void)
+#else
+void __attribute__((interrupt(),nomips16)) IntDtwi1Handler(void)
+#endif
+{
+    DTWI1::pDTWI1->stateMachine();
+}
+#endif
+
+#ifdef _DTWI2_BASE
+DTWI2 * DTWI2::pDTWI2 = NULL;
+
+// the class methods
+DTWI2::DTWI2() : DTWI(((p32_i2c *) _DTWI2_BASE), _DTWI2_BUS_IRQ, _DTWI2_VECTOR, _DTWI2_IPL, _DTWI2_SPL, _DTWI2_SCL_PIN, _DTWI2_SDA_PIN) 
+{
+    // save the instance away so the interrupt routine can
+    // get back to this instance
+    pDTWI2 = this;
+
+    // set the interrupt vector
+    setIntVector(_DTWI2_VECTOR, IntDtwi2Handler);
+};
+
+// the associated interrupt routine.
+#if defined(__PIC32MZXX__)
+void __attribute__((nomips16,vector(_DTWI2_VECTOR),interrupt(_DTWI2_IPL_ISR))) IntDtwi2Handler(void)
+#else
+void __attribute__((interrupt(),nomips16)) IntDtwi2Handler(void)
+#endif
+{
+    DTWI2::pDTWI2->stateMachine();
+}
+#endif
+
+#ifdef _DTWI3_BASE
+DTWI3 * DTWI3::pDTWI3 = NULL;
+
+// the class methods
+DTWI3::DTWI3() : DTWI(((p32_i2c *) _DTWI3_BASE), _DTWI3_BUS_IRQ, _DTWI3_VECTOR, _DTWI3_IPL, _DTWI3_SPL, _DTWI3_SCL_PIN, _DTWI3_SDA_PIN) 
+{
+    // save the instance away so the interrupt routine can
+    // get back to this instance
+    pDTWI3 = this;
+
+    // set the interrupt vector
+    setIntVector(_DTWI3_VECTOR, IntDtwi3Handler);
+};
+
+// the associated interrupt routine.
+#if defined(__PIC32MZXX__)
+void __attribute__((nomips16,vector(_DTWI3_VECTOR),interrupt(_DTWI3_IPL_ISR))) IntDtwi3Handler(void)
+#else
+void __attribute__((interrupt(),nomips16)) IntDtwi3Handler(void)
+#endif
+{
+    DTWI3::pDTWI3->stateMachine();
+}
+#endif
+
+#ifdef _DTWI4_BASE
+DTWI4 * DTWI4::pDTWI4 = NULL;
+
+// the class methods
+DTWI4::DTWI4() : DTWI(((p32_i2c *) _DTWI4_BASE), _DTWI4_BUS_IRQ, _DTWI4_VECTOR, _DTWI4_IPL, _DTWI4_SPL, _DTWI4_SCL_PIN, _DTWI4_SDA_PIN) 
+{
+    // save the instance away so the interrupt routine can
+    // get back to this instance
+    pDTWI4 = this;
+
+    // set the interrupt vector
+    setIntVector(_DTWI4_VECTOR, IntDtwi4Handler);
+};
+
+// the associated interrupt routine.
+#if defined(__PIC32MZXX__)
+void __attribute__((nomips16,vector(_DTWI4_VECTOR),interrupt(_DTWI4_IPL_ISR))) IntDtwi4Handler(void)
+#else
+void __attribute__((interrupt(),nomips16)) IntDtwi4Handler(void)
+#endif
+{
+    DTWI4::pDTWI4->stateMachine();
+}
+#endif
+
+
+

--- a/hardware/pic32/libraries/Wire/DTWI.h
+++ b/hardware/pic32/libraries/Wire/DTWI.h
@@ -1,0 +1,338 @@
+/************************************************************************/
+/*                                                                      */
+/*    DTWI.h                                                            */
+/*                                                                      */
+/*    I2C  implemenation                                                */
+/*                                                                      */
+/************************************************************************/
+/*    Author:     Keith Vogel                                           */
+/*    Copyright 2014, Digilent Inc.                                     */
+/************************************************************************/
+/* 
+*
+* Copyright (c) 2013-2014, Digilent <www.digilentinc.com>
+* Contact Digilent for the latest version.
+*
+* This program is free software; distributed under the terms of 
+* BSD 3-clause license ("Revised BSD License", "New BSD License", or "Modified BSD License")
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1.    Redistributions of source code must retain the above copyright notice, this
+*        list of conditions and the following disclaimer.
+* 2.    Redistributions in binary form must reproduce the above copyright notice,
+*        this list of conditions and the following disclaimer in the documentation
+*        and/or other materials provided with the distribution.
+* 3.    Neither the name(s) of the above-listed copyright holder(s) nor the names
+*        of its contributors may be used to endorse or promote products derived
+*        from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+* OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+* OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/************************************************************************/
+/*  Revision History:                                                   */
+/*    8/4/2014(KeithV): Created                                         */
+/************************************************************************/
+#if !defined(_DTWI_H_)
+#define	_DTWI_H_
+
+#define OPT_SYSTEM_INTERNAL
+#define OPT_BOARD_INTERNAL
+#include	<WProgram.h>
+
+/* ------------------------------------------------------------ */
+/*					Miscellaneous Declarations					*/
+/* ------------------------------------------------------------ */
+
+
+/* ------------------------------------------------------------ */
+/*					Variable Declarations						*/
+/* ------------------------------------------------------------ */
+
+
+/* ------------------------------------------------------------ */
+/*					Function Declarations						*/
+/* ------------------------------------------------------------ */
+
+/* Forward declarations for the interrupt service routines.
+** These functions need to be declared so that they can be declared
+** as friends of the DSPI class, so that they can call the private
+** method doDspiInterrupt
+*/
+#ifdef __cplusplus
+extern "C" {
+	void __attribute__((nomips16)) IntDtwi0Handler(void);
+	void __attribute__((nomips16)) IntDtwi1Handler(void);
+	void __attribute__((nomips16)) IntDtwi2Handler(void);
+	void __attribute__((nomips16)) IntDtwi3Handler(void);
+	void __attribute__((nomips16)) IntDtwi4Handler(void);
+};
+
+/* ------------------------------------------------------------ */
+/*					Object Class Declarations					*/
+/* ------------------------------------------------------------ */
+
+class DTWI {
+
+    // needed to call the stateMachine
+    friend void __attribute__((nomips16)) IntDtwi0Handler(void);
+    friend void __attribute__((nomips16)) IntDtwi1Handler(void);
+    friend void __attribute__((nomips16)) IntDtwi2Handler(void);
+    friend void __attribute__((nomips16)) IntDtwi3Handler(void);
+    friend void __attribute__((nomips16)) IntDtwi4Handler(void);
+
+public:
+    uint8_t static const    addrGenCall         = 0;
+    uint8_t static const    addrStartByte       = 1;
+    uint8_t static const    addrCBUS0           = 2;
+    uint8_t static const    addrCBUS1           = 3;
+    uint8_t static const    addrDiffBusFormat0  = 4;
+    uint8_t static const    addrDiffBusFormat1  = 5;
+    uint8_t static const    addrResrv0          = 6;
+    uint8_t static const    addrResrv1          = 7;
+
+    // these are masks that can be used on I2C_STATUS.status dword
+    uint32_t static const   SLAVEADDR           = 0x0000FFFF;
+    uint32_t static const   SESSION_ID          = 0x000F0000;
+    uint32_t static const   GEN_CALL            = 0x10000000;
+    uint32_t static const   BUS_IN_USE          = 0x08000000;
+    uint32_t static const   MY_BUS              = 0x04000000;
+    uint32_t static const   MASTER_MODE         = 0x02000000;
+    uint32_t static const   SLAVE_MODE          = 0x01000000;
+    uint32_t static const   BUS_ERROR           = 0x00800000;
+    uint32_t static const   NAKING              = 0x00400000;
+    uint32_t static const   WRITE               = 0x00200000;
+    uint32_t static const   READ                = 0x00100000;
+
+    uint32_t static const   recvInfinite        = 0xFFFFFFFF;
+
+    typedef struct I2C_STATUS_T
+    {
+        union
+        {
+            uint32_t            status;             // 32 bit status word for faster access
+            struct 
+            {
+                uint16_t         addr;              // current slave address on the bus; only valid if fMyBus == true
+                union 
+                {
+                    uint16_t flags;
+                    struct
+                    {
+                        unsigned int    iSession    : 4;    // This is the current session ID, will change if another stop/start has occured
+                        bool            fRead       : 1;    // currently bytes are being recieved off of the bus
+                        bool            fWrite      : 1;    // currently bytes are being transmitted on the bus
+                        bool            fNacking    : 1;    // On read, a NAK will be asserted on the 9th bit
+                        bool            fBusError   : 1;    // a bus error has occured; interrupts are probably disabled
+                        bool            fSlave      : 1;    // I2C controller is in Slave mode
+                        bool            fMaster     : 1;    // I2C controller is in Master mode
+                        bool            fMyBus      : 1;    // You currently own the bus
+                        bool            fBusInUse   : 1;    // the bus is in use by you or someone else, there is a start conditon on the bus
+                        bool            fGenCall    : 1;    // In slave mode, the General call address will be accepted
+                        bool            resv        : 3;
+                    };
+                };
+            };
+        };
+    } __attribute__((packed)) I2C_STATUS;
+
+    typedef enum
+    {
+        FQ0Hz       = 0,
+        FQ100KHz    = 100000,
+        FQ400KHz    = 400000,
+        FQ1MHz      = 1000000
+    } I2C_FREQ;
+
+protected:
+	DTWI(p32_i2c * ptwiC, uint8_t irqBusC, uint8_t vecC, uint8_t iplC, uint8_t splC, uint8_t pinSCLC, uint8_t pinSDAC);
+
+private:
+
+    typedef enum
+    {
+        I2C_IDLE,
+        I2C_BUS_ERROR,
+        I2C_DATA_READ,
+        I2C_DATA_WRITE,
+        I2C_ACK,
+        I2C_WAIT,
+    } I2C_STATE;
+
+    I2C_STATE           curState;       // current state of the I2C controller
+    p32_i2c *           ptwi;           // i2c register
+    p32_regset *	    pregIfs;        // interrupt flag register
+    p32_regset *	    pregIec;        // interrupt enable register
+    uint32_t            bitB;           // interrupt Fault (Bus), bit for the IEC and IFS, shifted to the approprieate location
+    uint32_t            bitMASK;        // interrupt Mask currently in use, is Master, or Slave on?
+    uint32_t volatile   cbToNAK;        // how many bytes to read until a NAK is sent
+    bool     volatile   fStop;          // stop the MASTER after the reads or writes   
+    bool                fMasterMode;    // we are in master mode if true, slave mode if false
+    uint16_t            addr;           // address of current endpoint
+    uint8_t             irqBus;         // IRQ for the Fault, Master is +1, Slave is +2
+    uint8_t             vec;            // vector for all 3 IRQs on MX, vector for fault on MZ (Master is +1,Slave +2)
+    uint8_t             ipl;            // interrupt priority level
+    uint8_t             spl;            // interrupt subpriority level
+    uint8_t             pinSDA;         // so we can put the SDA in digial input mode
+    uint8_t             pinSCL;         // so we can put the SCL in digial input mode
+
+    // the only item modified by the interrupt routine is the pWriteNext pointer... everything else is stable in the interrupt routine
+    uint8_t volatile    iWriteNext;     // Next byte to write out
+    uint8_t             iWriteLast;     // one past the last byte to write out
+    uint8_t             iReadNext;      // Next byte to read
+    uint8_t volatile    iReadLast;      // one past the last byte to read
+    uint8_t volatile    iSession;       // The current session number
+    byte                rgbOut[32];     // Output buffer; max size 127, do not exceed
+    byte                rgbIn[32];      // Input buffer; max size 127, do not exceed
+  
+    DTWI();                             // do not allow constructor with no params
+
+    void __attribute__((nomips16)) stateMachine(void);
+    void __attribute__((nomips16)) slaveMachine(void);
+    void __attribute__((nomips16)) masterMachine(void);
+
+    void primeMasterSlave(void);
+    bool startMaster(uint8_t addrSlave, uint32_t cbRead, bool fRead);
+    void forceIdleState(void);
+
+public:
+
+    // MASTER methods
+    bool beginMaster(I2C_FREQ feqI2C=FQ100KHz);
+    void endMaster(void);
+
+    bool startMasterWrite(uint8_t addrSlave)
+    {
+        return(startMaster(addrSlave, 0, false));
+    }
+    bool startMasterRead(uint8_t addrSlave, uint32_t cbRead=recvInfinite)
+    {
+        return(startMaster(addrSlave, cbRead, true));
+    }
+    bool stopMaster(void);
+
+    // SLAVE methods
+    bool beginSlave(uint8_t addrSlave, uint32_t cbToNak, bool fGenCall);
+    bool beginSlave(uint8_t addrSlave)
+    {
+        return(beginSlave(addrSlave, recvInfinite, false));
+    }
+    bool beginSlave(uint8_t addrSlave, uint32_t cbToNak)
+    {
+        return(beginSlave(addrSlave, cbToNak, false));
+    }
+    bool beginSlave(uint8_t addrSlave, bool fGenCall)
+    {
+        return(beginSlave(addrSlave, recvInfinite, fGenCall));
+    }
+    bool endSlave(bool fForce = false);
+
+    // COMMON read methods to both Master and Slave
+    uint32_t read(byte * pb, uint32_t cbMax);
+    void discard(void);
+    uint32_t available(void)
+    {
+        // how many bytes in the recieve buffer still to read.
+        return(iReadLast - iReadNext);
+    }
+
+    // COMMON write methods to both Master and Slave
+    uint32_t write(const byte * pb, uint32_t cbWrite);
+    void abort(void);
+    uint32_t transmitting(void)
+    {
+        // how many bytes in the transmit buffer yet to write
+        return(iWriteLast - iWriteNext);
+    }
+
+    // COMMON methods to both Master and Slave
+    bool setNAK(uint32_t cbToNak);
+    I2C_STATUS getStatus(void);
+};
+
+#ifdef _DTWI0_BASE
+class DTWI0 : public DTWI {
+
+    // needed to get to pDTWI
+    friend void __attribute__((nomips16)) IntDtwi0Handler(void);
+
+private:
+    static DTWI0 * pDTWI0;
+
+public:
+    DTWI0();
+};
+#endif
+
+#ifdef _DTWI1_BASE
+class DTWI1 : public DTWI {
+
+    // needed to get to pDTWI
+    friend void __attribute__((nomips16)) IntDtwi1Handler(void);
+
+private:
+    static DTWI1 * pDTWI1;
+
+public:
+    DTWI1();
+};
+#endif
+
+#ifdef _DTWI2_BASE
+class DTWI2 : public DTWI {
+
+    // needed to get to pDTWI
+    friend void __attribute__((nomips16)) IntDtwi2Handler(void);
+
+private:
+    static DTWI2 * pDTWI2;
+
+public:
+    DTWI2();
+};
+#endif
+
+#ifdef _DTWI3_BASE
+class DTWI3 : public DTWI {
+
+    // needed to get to pDTWI
+    friend void __attribute__((nomips16)) IntDtwi3Handler(void);
+
+private:
+    static DTWI3 * pDTWI3;
+
+public:
+    DTWI3();
+};
+#endif
+
+#ifdef _DTWI4_BASE
+class DTWI4 : public DTWI {
+
+    // needed to get to pDTWI
+    friend void __attribute__((nomips16)) IntDtwi4Handler(void);
+
+private:
+    static DTWI4 * pDTWI4;
+
+public:
+    DTWI4();
+};
+#endif
+#endif // C++
+
+/* ------------------------------------------------------------ */
+
+#endif	// _DTWI_H_
+
+/************************************************************************/

--- a/hardware/pic32/libraries/Wire/examples/I2CMasterEEPROM/I2CMasterEEPROM.pde
+++ b/hardware/pic32/libraries/Wire/examples/I2CMasterEEPROM/I2CMasterEEPROM.pde
@@ -1,0 +1,355 @@
+/************************************************************************/
+/*                                                                      */
+/*    I2CMasterEEPROM                                                   */
+/*                                                                      */
+/*    Example sketch to program and read 24LCxxx EEPROMs                */
+/*                                                                      */
+/************************************************************************/
+/*    Author:     Keith Vogel                                           */
+/*    Copyright 2014, Digilent Inc.                                     */
+/************************************************************************/
+/* 
+*
+* Copyright (c) 2013-2014, Digilent <www.digilentinc.com>
+* Contact Digilent for the latest version.
+*
+* This program is free software; distributed under the terms of 
+* BSD 3-clause license ("Revised BSD License", "New BSD License", or "Modified BSD License")
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1.    Redistributions of source code must retain the above copyright notice, this
+*        list of conditions and the following disclaimer.
+* 2.    Redistributions in binary form must reproduce the above copyright notice,
+*        this list of conditions and the following disclaimer in the documentation
+*        and/or other materials provided with the distribution.
+* 3.    Neither the name(s) of the above-listed copyright holder(s) nor the names
+*        of its contributors may be used to endorse or promote products derived
+*        from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+* OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+* OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/************************************************************************/
+/*  Revision History:                                                   */
+/*    8/4/2014(KeithV): Created                                         */
+/************************************************************************/
+
+#include <DTWI.h>
+
+//#define I2CADDR 0x50     // on board EEPROM, chipKIT Pro MX4, Network Shield
+#define I2CADDR 0x44     // Slave address for the I2CSlaveSimEEPROM sketch
+
+// create the DTWI object
+DTWI0 dtwi0;
+
+typedef enum {
+    NONE,
+    QUERYBUTTONPRESS,
+    WAITBUTTONPRESS,
+    WAITBUTTONRELEASE,
+    BEGINMASTER,
+    ENDMASTER,
+    STARTMASTERWRITE,
+    SAVE,
+    RESTARTMASTERWRITE,
+    RESTARTMASTERREAD,
+    ADDRWRITE,
+    ADDRREAD,
+    WRITEDATA,
+    READDATA,
+    STOPMASTER,
+    ERROR,
+    DONE,
+} TWISTATE;
+
+TWISTATE twiState = NONE;
+
+// make this 64 bytes which is the size of the page write buffer in the 24LCxxx
+// read the documentation carefully, the eeprom can be programmed in 64 byte pages,
+// however the pages are 64 byte aligned in the eeprom space. So be starting at an 
+// address not 64 byte aligned will cause a wrap in the eeprom program address space
+// when programmed. In our example we write at address 0x10, write 64 bytes which
+// will then wrap back to zero when 0x40 is hit, and the first 16 byes in the eeprom
+// are written. When we read back, we read back at address 0x00 and we will see those
+// last 16 bytes written starting at location 0
+static const byte rgbDataWrite[] = {    0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0x00, 
+                                        0x11, 0x21, 0x31, 0x41, 0x51, 0x61, 0x71, 0x81, 0x91, 0x01,  
+                                        0x12, 0x22, 0x32, 0x42, 0x52, 0x62, 0x72, 0x82, 0x92, 0x02,  
+                                        0x13, 0x23, 0x33, 0x43, 0x53, 0x63, 0x73, 0x83, 0x93, 0x03,  
+                                        0x14, 0x24, 0x34, 0x44, 0x54, 0x64, 0x74, 0x84, 0x94, 0x04,    
+                                        0x15, 0x25, 0x35, 0x45, 0x55, 0x65, 0x75, 0x85, 0x95, 0x05,  
+                                        0x16, 0x26, 0x36, 0x46 
+                                    };
+
+
+static uint32_t cbWritten = 0;
+static uint32_t cbRead = 0;
+
+// Read the 24LCxxx Datasheet carefully. ALL WRITES to the EEPROM are 64 byte aligned in the
+// address space and will wrap on the 64 byte boundary. By starting at 0x10, only 48 bytes will
+// write to the addresses we expect, after 48 bytes, the address will wrap to 0 ans start writing from there
+static const byte rgbEEPromAddrWrite[2] = {0x00, 0x10};  // high btye, low byte order.
+
+// by reading from the 64 byte aligned boundary (of 0) we can see how the bytes after the first 16 bytes
+// wrapped around to the begining of the 64 byte aligned locations
+static const byte rgbEEPromAddrRead[2] = {0x00, 0x00};  // high btye, low byte order.
+
+/***    void setup()
+ *
+ *    Parameters:
+ *          None
+ *              
+ *    Return Values:
+ *          None
+ *
+ *    Description: 
+ *    
+ *      Arduino setup routine
+ * ------------------------------------------------------------ */
+void setup() {
+
+    Serial.begin(9600);
+    Serial.println("I2CMasterEEPROM v3.0");
+    Serial.println("Example sketch to read I2C 24LCxxx EEPROMs");
+    Serial.println("Written by: Keith Vogel");
+    Serial.println("Copyright Digilent 2014");
+
+
+// if the WF32, turn on the pullup resistors
+#ifdef _BOARD_WF32_
+    pinMode(62, OUTPUT); 
+    pinMode(63, OUTPUT); 
+    digitalWrite(62, HIGH);
+    digitalWrite(63, HIGH);
+#endif
+
+#ifdef PIN_BTN1
+    pinMode(PIN_BTN1, INPUT); 
+    twiState = QUERYBUTTONPRESS;
+#else
+    twiState = BEGINMASTER;
+#endif
+}
+
+/***    void setup()
+ *
+ *    Parameters:
+ *          None
+ *              
+ *    Return Values:
+ *          None
+ *
+ *    Description: 
+ *    
+ *      Arduino loop routine
+ * ------------------------------------------------------------ */
+void loop() {
+
+    switch(twiState) 
+    {
+
+#ifdef PIN_BTN1
+        case QUERYBUTTONPRESS:
+            Serial.println("Press BTN to query EEPROM");
+            twiState = WAITBUTTONPRESS;
+            break;
+
+        case WAITBUTTONPRESS:
+            if(digitalRead(PIN_BTN1) == HIGH)
+            {
+                twiState = WAITBUTTONRELEASE;
+            }
+            break;
+
+        case WAITBUTTONRELEASE:
+            if(digitalRead(PIN_BTN1) == LOW)
+            {
+                delay(1);   // some debounce
+                twiState = BEGINMASTER;
+            }
+            break;
+#endif
+
+        case BEGINMASTER:
+            if(dtwi0.beginMaster())
+            {
+                int i;
+                twiState = STARTMASTERWRITE;
+
+                // put this print out now, because once I start the master I don't want
+                // the serial prints to block writing to the I2C bus; it won't hurt, it will
+                // just put a multi-millisecond delay in while this message prints. 
+                Serial.print("Writing ");
+                Serial.print((uint32_t) sizeof(rgbDataWrite), DEC);
+                Serial.print(" bytes to eeprom address: 0x");             
+                Serial.print((((uint32_t) rgbEEPromAddrWrite[0]) << 8) + rgbEEPromAddrWrite[1], HEX);
+
+                for(i = 0; i < sizeof(rgbDataWrite); i++)
+                {
+                    if((i % 16) == 0)
+                    {
+                        Serial.println();
+                    }
+                    Serial.print("0x");
+                    Serial.print(rgbDataWrite[i], HEX);
+                    Serial.print(" ");
+                }
+                Serial.println();
+            }
+            else
+            {
+                twiState = ERROR;
+            }
+            break;
+
+        case STARTMASTERWRITE:
+            if(dtwi0.startMasterWrite(I2CADDR))
+            {
+                cbWritten = 0;
+                twiState = ADDRWRITE;
+            }
+            else
+            {
+                twiState = ERROR;
+            }
+            break;
+
+        case ADDRWRITE:
+
+            if(cbWritten < sizeof(rgbEEPromAddrWrite))
+            {
+                cbWritten += dtwi0.write(&rgbEEPromAddrWrite[cbWritten], sizeof(rgbEEPromAddrWrite) - cbWritten);
+            }
+            else
+            {
+                twiState = WRITEDATA;
+                cbWritten = 0;
+            }            
+            break;
+
+        case WRITEDATA:
+
+            if(cbWritten < sizeof(rgbDataWrite))
+            {
+                cbWritten += dtwi0.write(&rgbDataWrite[cbWritten], sizeof(rgbDataWrite) - cbWritten);
+            }
+            else
+            {
+                twiState = SAVE;
+            }            
+            break;
+
+        case SAVE:
+            if(dtwi0.stopMaster())
+            {
+                twiState = RESTARTMASTERWRITE;    
+            }
+            break;
+
+        case RESTARTMASTERWRITE:
+            // this can fail because the EEPROM is busy
+            if(dtwi0.startMasterWrite(I2CADDR))
+            {
+                cbWritten = 0;
+                twiState = ADDRREAD;
+            }
+            break;
+
+        case ADDRREAD:
+
+            if(cbWritten < sizeof(rgbEEPromAddrRead))
+            {
+                cbWritten += dtwi0.write(&rgbEEPromAddrRead[cbWritten], sizeof(rgbEEPromAddrRead) - cbWritten);
+            }
+            else
+            {
+                twiState = RESTARTMASTERREAD;
+                cbWritten = 0;
+            }            
+            break;
+
+        case RESTARTMASTERREAD:
+            if(dtwi0.startMasterRead(I2CADDR, sizeof(rgbDataWrite)))
+            {
+                cbRead = 0;
+                twiState = READDATA;
+                Serial.println("Reading eeprom data back");
+            }
+            break;
+
+        case READDATA:
+            if(dtwi0.available())
+            {
+                int i = 0;
+                byte rgb[32];  
+                uint32_t cbReadThisPass = dtwi0.read(rgb, sizeof(rgb));
+                uint32_t readAddr = (((uint32_t) rgbEEPromAddrRead[0]) << 8) + rgbEEPromAddrRead[1] + cbRead;
+
+                Serial.print("eeprom addr 0x");
+                Serial.print(readAddr, HEX);
+                Serial.print(": ");
+
+                cbRead += cbReadThisPass;
+
+                for(i = 0; i < cbReadThisPass; i++)
+                {
+                    Serial.print("0x");
+                    Serial.print(rgb[i], HEX);
+                    Serial.print(" ");
+                }
+                Serial.println();
+
+                if(cbRead >= sizeof(rgbDataWrite))
+                {
+                    twiState = STOPMASTER;
+                }
+            }
+            break;
+
+        case STOPMASTER:
+            if(dtwi0.stopMaster())
+            {
+                twiState = ENDMASTER;    
+            }
+            break;
+
+        case ENDMASTER:
+            dtwi0.endMaster();
+
+            // clean out the read / write buffer
+            dtwi0.abort();
+            dtwi0.discard();
+
+#ifdef PIN_BTN1
+            twiState = QUERYBUTTONPRESS;
+#else
+            Serial.println("Sketch is done");
+            twiState = DONE;   
+#endif 
+            break;
+
+        case ERROR:
+            Serial.println("Got an error, ending sketch");
+#ifdef PIN_BTN1
+            twiState = ENDMASTER;
+#else
+            Serial.println("Sketch is done");
+            twiState = DONE;   
+#endif 
+            break;
+
+        DONE:
+        default:
+            break;
+    }
+}

--- a/hardware/pic32/libraries/Wire/examples/I2CSlaveSimEEPROM/I2CSlaveSimEEPROM.pde
+++ b/hardware/pic32/libraries/Wire/examples/I2CSlaveSimEEPROM/I2CSlaveSimEEPROM.pde
@@ -1,0 +1,310 @@
+/************************************************************************/
+/*                                                                      */
+/*    I2CSlaveSimEEPROM.cpp                                             */
+/*                                                                      */
+/*    Example sketch to emulate a 24LCxxx (24LC1) (1K) EEPROM           */
+/*                                                                      */
+/************************************************************************/
+/*    Author:     Keith Vogel                                           */
+/*    Copyright 2014, Digilent Inc.                                     */
+/************************************************************************/
+/* 
+*
+* Copyright (c) 2013-2014, Digilent <www.digilentinc.com>
+* Contact Digilent for the latest version.
+*
+* This program is free software; distributed under the terms of 
+* BSD 3-clause license ("Revised BSD License", "New BSD License", or "Modified BSD License")
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1.    Redistributions of source code must retain the above copyright notice, this
+*        list of conditions and the following disclaimer.
+* 2.    Redistributions in binary form must reproduce the above copyright notice,
+*        this list of conditions and the following disclaimer in the documentation
+*        and/or other materials provided with the distribution.
+* 3.    Neither the name(s) of the above-listed copyright holder(s) nor the names
+*        of its contributors may be used to endorse or promote products derived
+*        from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+* OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+* OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/************************************************************************/
+/*  Revision History:                                                   */
+/*    8/4/2014(KeithV): Created                                         */
+/************************************************************************/
+
+#include <DTWI.h>
+
+#define I2CADDR 0x44     // slave address
+
+// how long to be offline while updating the eeprom flash
+#define microWAIT 250
+
+// create the DTWI object
+DTWI0 dtwi0;
+
+typedef enum {
+    NONE,
+    BEGINSLAVE,
+    WAITMYBUS,
+    WAITEEPROMADDRESS,
+    WRITERAM,
+    READRAM,
+    PGMFLASH,
+    DELAYSOME,
+    ERROR,
+    ENDSLAVE,
+    DONE,
+} TWISTATE;
+
+static TWISTATE twiState = NONE;
+static uint32_t tStart = 0;
+
+// The 64 byte eeprom page write buffer
+#define WBALIGNMASK 0xFFFFFFC0
+static byte rgbPageWriteBuffer[64]; 
+
+// depending on the eeprom, the size of the eeprom
+// is a mult of the page write buffer. The eeprom Digilent use
+// on the MX4ck or Network Shield is a 24LC256, a 256K eeprom or
+// 4000x the page write buffer. We don't have that much RAM to 
+// simulate the full 256K, so we are only going to have 1K 
+// or 16x; so this would be a 24LC1.... if it existed.
+#define mRAMvsPageWriteBuff  16
+static byte rgbSimEEProm[mRAMvsPageWriteBuff * sizeof(rgbPageWriteBuffer)];
+
+// the RAM address we are writing
+static uint16_t ramAddress = 0;
+static uint8_t curSession = 0;
+static bool fWriteRAM = false;
+
+/***    void setup()
+ *
+ *    Parameters:
+ *          None
+ *              
+ *    Return Values:
+ *          None
+ *
+ *    Description: 
+ *    
+ *      Arduino setup routine
+ * ------------------------------------------------------------ */
+void setup() {
+
+    Serial.begin(9600);
+    Serial.println("I2CSlaveSimEEPROM v2.0");
+    Serial.println("Simulated 24LCxxx EEPROM I2C Slave");
+    Serial.println("Written by: Keith Vogel");
+    Serial.println("Copyright Digilent 2014");
+
+// if the WF32, turn on the pullup resistors
+#ifdef _BOARD_WF32_
+    pinMode(62, OUTPUT); 
+    pinMode(63, OUTPUT); 
+    digitalWrite(62, HIGH);
+    digitalWrite(63, HIGH);
+#endif
+
+    // flash is originally erased to FFs
+    memset(rgbSimEEProm, 0xFF, sizeof(rgbSimEEProm));
+
+    // clean out the read / write buffers
+    // in the I2C controller
+    dtwi0.abort();
+    dtwi0.discard();
+
+    twiState = BEGINSLAVE;
+}
+
+/***    void setup()
+ *
+ *    Parameters:
+ *          None
+ *              
+ *    Return Values:
+ *          None
+ *
+ *    Description: 
+ *    
+ *      Arduino loop routine
+ * ------------------------------------------------------------ */
+void loop() {
+    DTWI::I2C_STATUS curStatus = dtwi0.getStatus();
+
+    switch(twiState) 
+    {
+        case BEGINSLAVE:
+            if(dtwi0.beginSlave(I2CADDR))
+            {
+                twiState = WAITMYBUS;
+            }
+            else
+            {
+                twiState = ENDSLAVE;
+            }
+            break;
+
+        case WAITMYBUS:
+            // about to recieve and address
+            if(curStatus.fRead)
+            {
+                twiState = WAITEEPROMADDRESS;
+                curSession = curStatus.iSession;
+            }
+
+            // if we get a write, just spit out data
+            else if(curStatus.fWrite)
+            {
+                twiState = READRAM;
+                curSession = curStatus.iSession;
+            }
+            break;
+
+        case WAITEEPROMADDRESS:
+            if(dtwi0.available() >= 2)
+            {
+                uint32_t iWriteBuffBase;
+
+                dtwi0.read(&((byte *) &ramAddress)[1], 1);
+                dtwi0.read(&((byte *) &ramAddress)[0], 1);
+
+                // we want to make sure the specified address
+                // wraps and is in the range of our sim eeprom 
+                ramAddress %= sizeof(rgbSimEEProm);
+                iWriteBuffBase = ramAddress & WBALIGNMASK;
+
+                // we must preload our page write buffer with
+                // contents of the eeprom; remember to read the aligned values in
+                memcpy(rgbPageWriteBuffer, &rgbSimEEProm[iWriteBuffBase], sizeof(rgbPageWriteBuffer));
+
+                // go to getting the data
+                fWriteRAM = false;
+                twiState = WRITERAM;
+           }
+
+            // if somehow we are not on a read...
+            // but we are waiting for an address, so this doesn't
+            // make any sense, go back and wait for a restart
+            else if(curSession != curStatus.iSession || !curStatus.fMyBus)
+            {
+                twiState = ENDSLAVE;
+            }
+            break;
+
+        case WRITERAM:           
+            // consume anything we have in the buffer
+            while(dtwi0.available() > 0)
+            {
+                // location of the address is page write buffer aligned
+                // within the eeprom
+                uint32_t iPageWriteBuff = ramAddress % sizeof(rgbPageWriteBuffer);
+                uint32_t cbRead = min(sizeof(rgbPageWriteBuffer) - iPageWriteBuff, dtwi0.available());
+
+                // read the data into the write page buffer
+                dtwi0.read(&rgbPageWriteBuffer[iPageWriteBuff], cbRead);
+
+                // update the ramAddress based on the page write buffer address wrapping
+                ramAddress = (ramAddress & WBALIGNMASK) + ((iPageWriteBuff + cbRead) % sizeof(rgbPageWriteBuffer));
+
+                fWriteRAM = true;
+            }
+
+            // as soon as we lose the bus, shutdown the controller
+            // this will give us time to read the rest of the data and 
+            // write sim eeprom
+            if(!curStatus.fBusInUse && fWriteRAM)
+            {
+                // we want to immediately turn OFF the controller
+                // we do not want to respond to new address requests
+                dtwi0.endSlave(true);
+                twiState = PGMFLASH;
+            }
+
+            // if I lost the session, don't write the eeprom
+            // just go back and look for another command
+            else if(!curStatus.fMyBus || curStatus.iSession != curSession)
+            {
+                twiState = WAITMYBUS;
+            }
+
+            break;
+
+        case READRAM:
+            if(dtwi0.transmitting() < 10)
+            {
+                dtwi0.write(&rgbSimEEProm[ramAddress++], 1);
+                ramAddress %= sizeof(rgbSimEEProm);
+            }
+            else if(!curStatus.fMyBus || curStatus.iSession != curSession)
+            {
+                // clean out the write buffer
+                twiState = ENDSLAVE;
+            }
+            break;      
+
+        case PGMFLASH:
+            // we must write back our page write buffer to
+            // simulated eeprom
+            memcpy(&rgbSimEEProm[(ramAddress & WBALIGNMASK)], rgbPageWriteBuffer, sizeof(rgbPageWriteBuffer));
+
+            // clean out the read / write buffer
+            dtwi0.abort();
+            dtwi0.discard();
+
+            // now simulate flash write time
+            tStart = micros();
+            twiState = DELAYSOME;    
+            break;
+
+        case DELAYSOME:
+            // the 24LCxxxx will be knocked off line as a slave
+            // while it updates the eeprom from the write buffer
+            // a real 24LCxxxx will be off line for many millisec
+            // but as an emulations, we just want to be off line
+            // long enough to show we went off line, so our emulation
+            // is much shorter.
+            if( micros() - tStart >= microWAIT)
+            {
+                // start over, wait for another slave command
+                twiState = BEGINSLAVE;  
+            }
+            break;
+
+        case ENDSLAVE:
+            // forcefully end the slave
+            dtwi0.endSlave(true);
+
+            // clean the buffers up
+            dtwi0.abort();
+            dtwi0.discard();
+
+            // start over, wait for another slave command
+            twiState = BEGINSLAVE;  
+            break;
+
+        case ERROR:
+            // forcefully end the slave
+            dtwi0.endSlave(true);
+            tStart = micros();
+
+            Serial.println("Got an error, ending sketch");
+            twiState = DELAYSOME;
+            break;
+
+        DONE:
+        default:
+            break;
+    }
+}

--- a/hardware/pic32/variants/CUI32stem/Board_Defs.h
+++ b/hardware/pic32/variants/CUI32stem/Board_Defs.h
@@ -69,7 +69,7 @@
 #define	NUM_I2C_PORTS		1
 
 #define NUM_DSPI_PORTS		1
-#define NUM_DTWI_PORTS		2
+#define NUM_DTWI_PORTS		1
 
 /* Define I/O devices on the board.
 */
@@ -282,18 +282,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART2
 */
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -308,9 +308,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SPI_RX_IRQ		_SPI2_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI2_TX_IRQ
 #define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define	_SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses the same port.
 */
@@ -319,9 +319,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define	_DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define	_DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -337,9 +337,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define	_TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define	_TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
 **		DTWI0 is on A4/A5 (see above comment).
@@ -347,21 +347,21 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  58 
+#define _DTWI0_SDA_PIN  57
 
-#define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
-#define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
-#define	_DTWI1_VECTOR	_I2C_2_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI1_IPL		_I2C2_IPL_IPC
-#define	_DTWI1_SPL		_I2C2_SPL_IPC
+//#define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
+//#define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
+//#define	_DTWI1_VECTOR	_I2C_2_VECTOR
+//#define	_DTWI1_IPL_ISR	IPL3SOFT
+//#define	_DTWI1_IPL		3
+//#define	_DTWI1_SPL		0
+//#define _DTWI1_SCL_PIN  69 
+//#define _DTWI1_SDA_PIN  68
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Cerebot_32MX4/Board_Defs.h
+++ b/hardware/pic32/variants/Cerebot_32MX4/Board_Defs.h
@@ -301,18 +301,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART2
 */
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -325,9 +325,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SPI_RX_IRQ		_SPI2_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI2_TX_IRQ
 #define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define	_SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses these ports.
 **		DSPI0	connector JB
@@ -338,18 +338,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define	_DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define	_DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 #define	_DSPI1_BASE			_SPI1_BASE_ADDRESS
 #define	_DSPI1_ERR_IRQ		_SPI1_ERR_IRQ
 #define	_DSPI1_RX_IRQ		_SPI1_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI1_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_1_VECTOR
-#define	_DSPI1_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI1_IPL			_SPI1_IPL_IPC
-#define	_DSPI1_SPL			_SPI1_SPL_IPC
+#define	_DSPI1_IPL_ISR		IPL3SOFT
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -363,9 +363,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define	_TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define	_TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
 **		DTWI0 is on I2C2, connector J2
@@ -373,23 +373,23 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 **
 ** DTWI1 has the I2C EEPROM and DAC.
 */
-#define	_DTWI0_BASE		_I2C2_BASE_ADDRESS
-#define	_DTWI0_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C2_MASTER_IRQ
-#define	_DTWI0_VECTOR	_I2C_2_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI0_IPL		_I2C2_IPL_IPC
-#define	_DTWI0_SPL		_I2C2_SPL_IPC
+#define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
+#define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
+#define	_DTWI0_VECTOR	_I2C_1_VECTOR
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  40 
+#define _DTWI0_SDA_PIN  41
 
-#define	_DTWI1_BASE		_I2C1_BASE_ADDRESS
-#define	_DTWI1_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C1_MASTER_IRQ
-#define	_DTWI1_VECTOR	_I2C_1_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI1_IPL		_I2C1_IPL_IPC
-#define	_DTWI1_SPL		_I2C1_SPL_IPC
+#define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
+#define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
+#define	_DTWI1_VECTOR	_I2C_2_VECTOR
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  68 
+#define _DTWI1_SDA_PIN  69
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Cerebot_32MX7/Board_Defs.h
+++ b/hardware/pic32/variants/Cerebot_32MX7/Board_Defs.h
@@ -293,18 +293,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART2. Connector JF
 */
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -317,9 +317,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SPI_RX_IRQ		_SPI4_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI4_TX_IRQ
 #define	_SPI_VECTOR		_SPI_4_VECTOR
-#define	_SPI_IPL_ISR	_SPI4_IPL_ISR
-#define	_SPI_IPL		_SPI4_IPL_IPC
-#define	_SPI_SPL		_SPI4_SPL_IPC
+#define	_SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses these ports.
 **		DSPI0	connector JD
@@ -331,9 +331,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI1_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI1_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_1_VECTOR
-#define	_DSPI0_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI0_IPL			_SPI1_IPL_IPC
-#define	_DSPI0_SPL			_SPI1_SPL_IPC
+#define	_DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 #define	_SPI3_ERR_IRQ	_SPI1A_ERR_IRQ	//this definition is missing from
 										// the Microchip header file.
@@ -342,18 +342,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DSPI1_RX_IRQ		_SPI3_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI3_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_3_VECTOR
-#define	_DSPI1_IPL_ISR		_SPI3_IPL_ISR
-#define	_DSPI1_IPL			_SPI3_IPL_IPC
-#define	_DSPI1_SPL			_SPI3_SPL_IPC
+#define	_DSPI1_IPL_ISR		IPL3SOFT
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 #define	_DSPI2_BASE			_SPI4_BASE_ADDRESS
 #define	_DSPI2_ERR_IRQ		_SPI4_ERR_IRQ
 #define	_DSPI2_RX_IRQ		_SPI4_RX_IRQ
 #define	_DSPI2_TX_IRQ		_SPI4_TX_IRQ
 #define	_DSPI2_VECTOR		_SPI_4_VECTOR
-#define	_DSPI2_IPL_ISR		_SPI4_IPL_ISR
-#define	_DSPI2_IPL			_SPI4_IPL_IPC
-#define	_DSPI2_SPL			_SPI4_SPL_IPC
+#define	_DSPI2_IPL_ISR		IPL3SOFT
+#define	_DSPI2_IPL			3
+#define	_DSPI2_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -367,9 +367,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define	_TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define	_TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library. DTWI0 and DTWI1 are
 ** connected to the 2x4 I2C daisy chain connectors. The pins for the
@@ -381,39 +381,39 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 */
 #define	_DTWI0_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_2_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI0_IPL		_I2C2_IPL_IPC
-#define	_DTWI0_SPL		_I2C2_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  57 
+#define _DTWI0_SDA_PIN  58
 
 #define	_DTWI1_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_1_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI1_IPL		_I2C1_IPL_IPC
-#define	_DTWI1_SPL		_I2C1_SPL_IPC
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  55 
+#define _DTWI1_SDA_PIN  56
 
 #define	_DTWI2_BASE		_I2C3_BASE_ADDRESS
 #define	_DTWI2_BUS_IRQ	_I2C3_BUS_IRQ
-#define	_DTWI2_SLV_IRQ	_I2C3_SLAVE_IRQ
-#define	_DTWI2_MST_IRQ	_I2C3_MASTER_IRQ
 #define	_DTWI2_VECTOR	_I2C_3_VECTOR
-#define	_DTWI2_IPL_ISR	_I2C3_IPL_ISR
-#define	_DTWI2_IPL		_I2C3_IPL_IPC
-#define	_DTWI2_SPL		_I2C3_SPL_IPC
+#define	_DTWI2_IPL_ISR	IPL3SOFT
+#define	_DTWI2_IPL		3
+#define	_DTWI2_SPL		0
+#define _DTWI2_SCL_PIN  33 
+#define _DTWI2_SDA_PIN  34
 
 #define	_DTWI3_BASE		_I2C5_BASE_ADDRESS
 #define	_DTWI3_BUS_IRQ	_I2C5_BUS_IRQ
-#define	_DTWI3_SLV_IRQ	_I2C5_SLAVE_IRQ
-#define	_DTWI3_MST_IRQ	_I2C5_MASTER_IRQ
 #define	_DTWI3_VECTOR	_I2C_5_VECTOR
-#define	_DTWI3_IPL_ISR	_I2C5_IPL_ISR
-#define	_DTWI3_IPL		_I2C5_IPL_IPC
-#define	_DTWI3_SPL		_I2C5_SPL_IPC
+#define	_DTWI3_IPL_ISR	IPL3SOFT
+#define	_DTWI3_IPL		3
+#define	_DTWI3_SPL		0
+#define _DTWI3_SCL_PIN  41 
+#define _DTWI3_SDA_PIN  42
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Cerebot_GA4/Board_Defs.h
+++ b/hardware/pic32/variants/Cerebot_GA4/Board_Defs.h
@@ -284,9 +284,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 #define	_SER0_TX_OUT	PPS_OUT_U1TX
 #define	_SER0_TX_PIN	8
 #define	_SER0_RX_IN		PPS_IN_U1RX
@@ -297,9 +297,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 #define	_SER1_TX_OUT	PPS_OUT_U2TX
 #define	_SER1_TX_PIN	2
 #define	_SER1_RX_IN		PPS_IN_U2RX

--- a/hardware/pic32/variants/Cerebot_MX3cK/Board_Defs.h
+++ b/hardware/pic32/variants/Cerebot_MX3cK/Board_Defs.h
@@ -284,18 +284,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART2
 */
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -355,21 +355,21 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
 #define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
 #define	_DTWI0_IPL		_I2C1_IPL_IPC
 #define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define _DTWI0_SCL_PIN  41 
+#define _DTWI0_SDA_PIN  44
 
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
 #define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
 #define	_DTWI1_IPL		_I2C2_IPL_IPC
 #define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define _DTWI1_SCL_PIN  17 
+#define _DTWI1_SDA_PIN  18
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Cerebot_MX3cK_512/Board_Defs.h
+++ b/hardware/pic32/variants/Cerebot_MX3cK_512/Board_Defs.h
@@ -302,18 +302,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART2
 */
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -373,21 +373,21 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
 #define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
 #define	_DTWI0_IPL		_I2C1_IPL_IPC
 #define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define _DTWI0_SCL_PIN  41 
+#define _DTWI0_SDA_PIN  44
 
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
 #define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
 #define	_DTWI1_IPL		_I2C2_IPL_IPC
 #define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define _DTWI1_SCL_PIN  17 
+#define _DTWI1_SDA_PIN  18
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Cerebot_MX4cK/Board_Defs.h
+++ b/hardware/pic32/variants/Cerebot_MX4cK/Board_Defs.h
@@ -302,18 +302,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART2
 */
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -376,21 +376,21 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
 #define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
 #define	_DTWI0_IPL		_I2C1_IPL_IPC
 #define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define _DTWI0_SCL_PIN  40 
+#define _DTWI0_SDA_PIN  41
 
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
 #define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
 #define	_DTWI1_IPL		_I2C2_IPL_IPC
 #define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define _DTWI1_SCL_PIN  72 
+#define _DTWI1_SDA_PIN  73
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Cerebot_MX7cK/Board_Defs.h
+++ b/hardware/pic32/variants/Cerebot_MX7cK/Board_Defs.h
@@ -294,18 +294,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART2. Connector JF
 */
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -380,41 +380,41 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 **		DTWI2 is on JE (pins 2&3), digital pins 33 (SCL) & 34 (SDA)
 **		DTWI3 is on JF (pins 2&3), digital pins 41 (SCL) & 42 (SDA)
 */
-#define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
-#define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
-#define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_BASE		_I2C2_BASE_ADDRESS
+#define	_DTWI0_BUS_IRQ	_I2C2_BUS_IRQ
+#define	_DTWI0_VECTOR	_I2C_2_VECTOR
+#define	_DTWI0_IPL_ISR	_I2C2_IPL_ISR
+#define	_DTWI0_IPL		_I2C2_IPL_IPC
+#define	_DTWI0_SPL		_I2C2_SPL_IPC
+#define _DTWI0_SCL_PIN  57 
+#define _DTWI0_SDA_PIN  58
 
-#define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
-#define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
-#define	_DTWI1_VECTOR	_I2C_2_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI1_IPL		_I2C2_IPL_IPC
-#define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define	_DTWI1_BASE		_I2C1_BASE_ADDRESS
+#define	_DTWI1_BUS_IRQ	_I2C1_BUS_IRQ
+#define	_DTWI1_VECTOR	_I2C_1_VECTOR
+#define	_DTWI1_IPL_ISR	_I2C1_IPL_ISR
+#define	_DTWI1_IPL		_I2C1_IPL_IPC
+#define	_DTWI1_SPL		_I2C1_SPL_IPC
+#define _DTWI1_SCL_PIN  55 
+#define _DTWI1_SDA_PIN  56
 
 #define	_DTWI2_BASE		_I2C3_BASE_ADDRESS
 #define	_DTWI2_BUS_IRQ	_I2C3_BUS_IRQ
-#define	_DTWI2_SLV_IRQ	_I2C3_SLAVE_IRQ
-#define	_DTWI2_MST_IRQ	_I2C3_MASTER_IRQ
 #define	_DTWI2_VECTOR	_I2C_3_VECTOR
 #define	_DTWI2_IPL_ISR	_I2C3_IPL_ISR
 #define	_DTWI2_IPL		_I2C3_IPL_IPC
 #define	_DTWI2_SPL		_I2C3_SPL_IPC
+#define _DTWI2_SCL_PIN  33 
+#define _DTWI2_SDA_PIN  34
 
 #define	_DTWI3_BASE		_I2C5_BASE_ADDRESS
 #define	_DTWI3_BUS_IRQ	_I2C5_BUS_IRQ
-#define	_DTWI3_SLV_IRQ	_I2C5_SLAVE_IRQ
-#define	_DTWI3_MST_IRQ	_I2C5_MASTER_IRQ
 #define	_DTWI3_VECTOR	_I2C_5_VECTOR
 #define	_DTWI3_IPL_ISR	_I2C5_IPL_ISR
 #define	_DTWI3_IPL		_I2C5_IPL_IPC
 #define	_DTWI3_SPL		_I2C5_SPL_IPC
+#define _DTWI3_SCL_PIN  41 
+#define _DTWI3_SDA_PIN  42
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/ChipKIT_Pi/Board_Defs.h
+++ b/hardware/pic32/variants/ChipKIT_Pi/Board_Defs.h
@@ -281,9 +281,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define       _SER0_BASE           _UART1_BASE_ADDRESS
 #define       _SER0_IRQ            _UART1_ERR_IRQ
 #define       _SER0_VECTOR         _UART_1_VECTOR
-#define       _SER0_IPL_ISR        _UART1_IPL_ISR
-#define       _SER0_IPL            _UART1_IPL_IPC
-#define       _SER0_SPL            _UART1_SPL_IPC
+#define       _SER0_IPL_ISR        IPL2SOFT
+#define       _SER0_IPL            2
+#define       _SER0_SPL            0
 #define       _SER0_TX_OUT         PPS_OUT_U1TX     // RPB3R = U1TX = 1   
 #define       _SER0_TX_PIN         1                // RB4
 #define       _SER0_RX_IN          PPS_IN_U1RX      // U1RXR = RA4 = 0
@@ -295,9 +295,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define       _SER1_BASE           _UART2_BASE_ADDRESS
 #define       _SER1_IRQ            _UART2_ERR_IRQ
 #define       _SER1_VECTOR         _UART_2_VECTOR
-#define       _SER1_IPL_ISR        _UART2_IPL_ISR
-#define       _SER1_IPL            _UART2_IPL_IPC
-#define       _SER1_SPL            _UART2_SPL_IPC
+#define       _SER1_IPL_ISR        IPL2SOFT
+#define       _SER1_IPL            2
+#define       _SER1_SPL            0
 #define       _SER1_TX_OUT         PPS_OUT_U2TX     // RPB0R = U2TX = 5
 #define       _SER1_TX_PIN         5                // RB0
 #define       _SER1_RX_IN          PPS_IN_U2RX      // U2RXR = RPB1 = 4
@@ -382,12 +382,12 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 */
 #define	_DTWI0_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_2_VECTOR
 #define	_DTWI0_IPL_ISR	_I2C2_IPL_ISR
 #define	_DTWI0_IPL		_I2C2_IPL_IPC
 #define	_DTWI0_SPL		_I2C2_SPL_IPC
+#define _DTWI0_SCL_PIN  17 
+#define _DTWI0_SDA_PIN  16
 
 /* Declarations for Digilent DTWI library.
 ** DTWI0 is on PIC32 peripheral I2C1
@@ -396,12 +396,12 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 */
 #define	_DTWI1_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_1_VECTOR
 #define	_DTWI1_IPL_ISR	_I2C1_IPL_ISR
 #define	_DTWI1_IPL		_I2C1_IPL_IPC
 #define	_DTWI1_SPL		_I2C1_SPL_IPC
+#define _DTWI1_SCL_PIN  12 
+#define _DTWI1_SDA_PIN  18
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Cmod/Board_Defs.h
+++ b/hardware/pic32/variants/Cmod/Board_Defs.h
@@ -308,9 +308,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define       _SER0_BASE           _UART1_BASE_ADDRESS
 #define       _SER0_IRQ            _UART1_ERR_IRQ
 #define       _SER0_VECTOR         _UART_1_VECTOR
-#define       _SER0_IPL_ISR        _UART1_IPL_ISR
-#define       _SER0_IPL            _UART1_IPL_IPC
-#define       _SER0_SPL            _UART1_SPL_IPC
+#define       _SER0_IPL_ISR        IPL2SOFT
+#define       _SER0_IPL            2
+#define       _SER0_SPL            0
 #define       _SER0_TX_OUT         PPS_OUT_U1TX     // FTDI RxD (RPB3R = 0x1) RPB3 <- U1TX    
 #define       _SER0_TX_PIN         23               // 23  AN5/C1INA/C2INC/RTCC/RPB3/SCL2/RB3      
 #define       _SER0_RX_IN          PPS_IN_U1RX      // FTDI TxD (U1RXR = 0x5) RPC6 -> U1RX  
@@ -322,9 +322,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define       _SER1_BASE           _UART2_BASE_ADDRESS
 #define       _SER1_IRQ            _UART2_ERR_IRQ
 #define       _SER1_VECTOR         _UART_2_VECTOR
-#define       _SER1_IPL_ISR        _UART2_IPL_ISR
-#define       _SER1_IPL            _UART2_IPL_IPC
-#define       _SER1_SPL            _UART2_SPL_IPC
+#define       _SER1_IPL_ISR        IPL2SOFT
+#define       _SER1_IPL            2
+#define       _SER1_SPL            0
 #define       _SER1_TX_OUT         PPS_OUT_U2TX     // J2-2 (RPB0R = 0x2) RPB0 <- U2TX
 #define       _SER1_TX_PIN         20               // 20  RB0  PGED1/AN2/C1IND/C2INB/C3IND/RPB0/RB0
 #define       _SER1_RX_IN          PPS_IN_U2RX      // J2-3 (U2RXR = 0x2) RPB1 -> U2RX
@@ -424,12 +424,12 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
 #define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
 #define	_DTWI0_IPL		_I2C1_IPL_IPC
 #define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define _DTWI0_SCL_PIN  38 
+#define _DTWI0_SDA_PIN  4
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/DP32/Board_Defs.h
+++ b/hardware/pic32/variants/DP32/Board_Defs.h
@@ -289,9 +289,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define       _SER0_BASE           _UART1_BASE_ADDRESS
 #define       _SER0_IRQ            _UART1_ERR_IRQ
 #define       _SER0_VECTOR         _UART_1_VECTOR
-#define       _SER0_IPL_ISR        _UART1_IPL_ISR
-#define       _SER0_IPL            _UART1_IPL_IPC
-#define       _SER0_SPL            _UART1_SPL_IPC
+#define       _SER0_IPL_ISR        IPL2SOFT
+#define       _SER0_IPL            2
+#define       _SER0_SPL            0
 #define       _SER0_TX_OUT         PPS_OUT_U1TX     // RPB3R = U1TX = 1   
 #define       _SER0_TX_PIN         14               // RB3  AN5/C1INA/C2INC/RTCC/RPB3/SCL2/PMWR/RB3     
 #define       _SER0_RX_IN          PPS_IN_U1RX      // U1RXR = RPB13 = 3
@@ -303,9 +303,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define       _SER1_BASE           _UART2_BASE_ADDRESS
 #define       _SER1_IRQ            _UART2_ERR_IRQ
 #define       _SER1_VECTOR         _UART_2_VECTOR
-#define       _SER1_IPL_ISR        _UART2_IPL_ISR
-#define       _SER1_IPL            _UART2_IPL_IPC
-#define       _SER1_SPL            _UART2_SPL_IPC
+#define       _SER1_IPL_ISR        IPL2SOFT
+#define       _SER1_IPL            2
+#define       _SER1_SPL            0
 #define       _SER1_TX_OUT         PPS_OUT_U2TX     // RPB14R = U2TX = 2
 #define       _SER1_TX_PIN         7                // RB14 CVREF/AN10/C3INB/RPB14/VBUSON/SCK1/CTED5/RB14
 #define       _SER1_RX_IN          PPS_IN_U2RX      // U2RXR = RPA1 = 0
@@ -323,9 +323,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define	_SPI_RX_IRQ		_SPI1_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI1_TX_IRQ
 #define	_SPI_VECTOR		_SPI_1_VECTOR
-#define	_SPI_IPL_ISR	_SPI1_IPL_ISR
-#define	_SPI_IPL		_SPI1_IPL_IPC
-#define	_SPI_SPL		_SPI1_SPL_IPC
+#define	_SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* SPI pin declarations
 */
@@ -345,9 +345,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI1_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI1_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_1_VECTOR
-#define	_DSPI0_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI0_IPL			_SPI1_IPL_IPC
-#define	_DSPI0_SPL			_SPI1_SPL_IPC
+#define	_DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 #define _DSPI0_MISO_IN		PPS_IN_SDI1
 #define _DSPI0_MISO_PIN		10				// RA1  SDI1    SDI1R = RPA1 = 0 
@@ -365,9 +365,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define	_DSPI1_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_2_VECTOR
-#define	_DSPI1_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI1_IPL			_SPI2_IPL_IPC
-#define	_DSPI1_SPL			_SPI2_SPL_IPC
+#define	_DSPI1_IPL_ISR		IPL3SOFT
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 #define _DSPI1_MISO_IN		PPS_IN_SDI2
 #define _DSPI1_MISO_PIN		13				// RB2  SDI2    SDI2R = RPB2 = 4
@@ -386,33 +386,33 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define	_TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define	_TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
-**		DTWI0 is on RB8/RB9 pins 38/4 
+**		DTWI0 is on RB8/RB9 pins 2/3
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  2 
+#define _DTWI0_SDA_PIN  3
 
 /* Declarations for Digilent DTWI library.
-**		DTWI0 is on RB8/RB9 pins 38/4 
+**		DTWI0 is on RB2/RB3 pins 13/14
 */
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI1_IPL		_I2C2_IPL_IPC
-#define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  14 
+#define _DTWI1_SDA_PIN  13
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Default_100/Board_Defs.h
+++ b/hardware/pic32/variants/Default_100/Board_Defs.h
@@ -285,18 +285,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART2
 */
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -311,9 +311,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SPI_RX_IRQ		_SPI2_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI2_TX_IRQ
 #define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define	_SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses the same port.
 */
@@ -322,9 +322,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define	_DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define	_DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -340,9 +340,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define	_TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define	_TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
 **		DTWI0 is on A4/A5 (see above comment).
@@ -353,18 +353,22 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  21 
+#define _DTWI0_SDA_PIN  20
 
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
 #define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
 #define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI1_IPL		_I2C2_IPL_IPC
-#define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  12 
+#define _DTWI1_SDA_PIN  13
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Default_64/Board_Defs.h
+++ b/hardware/pic32/variants/Default_64/Board_Defs.h
@@ -282,18 +282,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART2
 */
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -308,9 +308,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SPI_RX_IRQ		_SPI2_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI2_TX_IRQ
 #define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define	_SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses the same port.
 */
@@ -319,9 +319,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define	_DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define	_DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -337,9 +337,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define	_TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define	_TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
 **		DTWI0 is on A4/A5 (see above comment).
@@ -350,18 +350,22 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  46 
+#define _DTWI0_SDA_PIN  45
 
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
 #define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
 #define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI1_IPL		_I2C2_IPL_IPC
-#define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  40 
+#define _DTWI1_SDA_PIN  39
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Fubarino_Mini/Board_Defs.h
+++ b/hardware/pic32/variants/Fubarino_Mini/Board_Defs.h
@@ -290,9 +290,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 #define	_SER0_TX_OUT	PPS_OUT_U1TX		// RPB4R = U1TX = 1
 #define	_SER0_TX_PIN	17					// RB4
 #define	_SER0_RX_IN		PPS_IN_U1RX			// U1RXR = RPA4 = 2
@@ -303,9 +303,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 #define	_SER1_TX_OUT	PPS_OUT_U2TX		// RPB9R = U2TX = 2
 #define	_SER1_TX_PIN	26					// RB9
 #define	_SER1_RX_IN		PPS_IN_U2RX			// U2RXR = RPB8 = 4
@@ -324,9 +324,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define	_SPI_RX_IRQ		_SPI2_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI2_TX_IRQ
 #define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define	_SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* SPI pin declarations
 */
@@ -343,9 +343,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI1_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI1_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_1_VECTOR
-#define	_DSPI0_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI0_IPL			_SPI1_IPL_IPC
-#define	_DSPI0_SPL			_SPI1_SPL_IPC
+#define	_DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 #define _DSPI0_MISO_IN		PPS_IN_SDI1
 #define _DSPI0_MISO_PIN		19
@@ -360,9 +360,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define	_DSPI1_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_2_VECTOR
-#define	_DSPI1_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI1_IPL			_SPI2_IPL_IPC
-#define	_DSPI1_SPL			_SPI2_SPL_IPC
+#define	_DSPI1_IPL_ISR		IPL3SOFT
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 #define _DSPI1_MISO_IN      PPS_IN_SDI2
 #define _DSPI1_MISO_PIN     MISO
@@ -382,9 +382,9 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define	_TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define	_TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
 **		DTWI0 is on Arduino pins 25 (SCL1) and 26 (SDA1).
@@ -392,21 +392,21 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  25 
+#define _DTWI0_SDA_PIN  26
 
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI1_IPL		_I2C2_IPL_IPC
-#define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  10 
+#define _DTWI1_SDA_PIN  9
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Fubarino_SD/Board_Defs.h
+++ b/hardware/pic32/variants/Fubarino_SD/Board_Defs.h
@@ -311,9 +311,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 //UART1 TX = PIC pin 51, RD3, Arduino pin 9
 //UART1 RX = PIC pin 50, RD2, Arduino pin 8
 
@@ -322,9 +322,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 //UART2 TX = PIC pin 32, RF5, Arduino pin 29
 //UART2 RX = PIC pin 31, RF4, Arduino pin 28
 
@@ -334,9 +334,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER2_BASE		_UART3_BASE_ADDRESS
 #define	_SER2_IRQ		_UART3_ERR_IRQ
 #define	_SER2_VECTOR	_UART_3_VECTOR
-#define	_SER2_IPL_ISR	_UART3_IPL_ISR
-#define	_SER2_IPL		_UART3_IPL_IPC
-#define	_SER2_SPL		_UART3_SPL_IPC
+#define	_SER2_IPL_ISR	IPL2SOFT
+#define	_SER2_IPL		2
+#define	_SER2_SPL		0
 //UART3 TX = PIC pin 6, RG8, Arduino pin 26/SDO (in use by SPI on Fubarino SD)
 //UART3 RX = PIC pin 5, RG7, Arduino pin 25/SDI (in use by SPI on Fubarino SD)
 #endif
@@ -347,9 +347,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER3_BASE		_UART4_BASE_ADDRESS
 #define	_SER3_IRQ		_UART4_ERR_IRQ
 #define	_SER3_VECTOR	_UART_4_VECTOR
-#define	_SER3_IPL_ISR	_UART4_IPL_ISR
-#define	_SER3_IPL		_UART4_IPL_IPC
-#define	_SER3_SPL		_UART4_SPL_IPC
+#define	_SER3_IPL_ISR	IPL2SOFT
+#define	_SER3_IPL		2
+#define	_SER3_SPL		0
 //UART4 TX = PIC pin 49, RD1, Arduino pin 7 
 //UART4 RX = PIC pin 43, RD9, Arduino pin 1
 #endif
@@ -360,9 +360,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER4_BASE		_UART5_BASE_ADDRESS
 #define	_SER4_IRQ		_UART5_ERR_IRQ
 #define	_SER4_VECTOR	_UART_5_VECTOR
-#define	_SER4_IPL_ISR	_UART5_IPL_ISR
-#define	_SER4_IPL		_UART5_IPL_IPC
-#define	_SER4_SPL		_UART5_SPL_IPC
+#define	_SER4_IPL_ISR	IPL2SOFT
+#define	_SER4_IPL		2
+#define	_SER4_SPL		0
 //UART5 TX = PIC pin 29, RB14, Arduino pin 43/A1 
 //UART5 RX = PIC pin 21, RB8, Arduino pin 37/A7
 #endif
@@ -373,9 +373,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER5_BASE		_UART6_BASE_ADDRESS
 #define	_SER5_IRQ		_UART6_ERR_IRQ
 #define	_SER5_VECTOR	_UART_6_VECTOR
-#define	_SER5_IPL_ISR	_UART6_IPL_ISR
-#define	_SER5_IPL		_UART6_IPL_IPC
-#define	_SER5_SPL		_UART6_SPL_IPC
+#define	_SER5_IPL_ISR	IPL2SOFT
+#define	_SER5_IPL		2
+#define	_SER5_SPL		0
 //UART6 TX = PIC pin 4, RG6, Arduino pin 24/SCK (in use by Fubarino SD SPI)
 //UART6 RX = PIC pin 8, RG9, Arduino pin 27/SS (in use by Fubarino SD SPI)
 #endif
@@ -393,9 +393,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SPI_RX_IRQ		_SPI2_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI2_TX_IRQ
 #define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define	_SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses the same port.
 */
@@ -404,18 +404,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define	_DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define	_DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 #define	_DSPI1_BASE			_SPI3_BASE_ADDRESS
 #define	_DSPI1_ERR_IRQ		_SPI3_ERR_IRQ
 #define	_DSPI1_RX_IRQ		_SPI3_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI3_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_3_VECTOR
-#define	_DSPI1_IPL_ISR		_SPI3_IPL_ISR
-#define	_DSPI1_IPL			_SPI3_IPL_IPC
-#define	_DSPI1_SPL			_SPI3_SPL_IPC
+#define	_DSPI1_IPL_ISR		IPL3SOFT
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -431,29 +431,43 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define	_TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define	_TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
-**		DTWI0 is on A4/A5 (see above comment).
-**		DTWI1 is on digital pins 38 & 39.
+**		DTWI0 is on 1/2
+**		DTWI1 is on digital pins 29/28
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  2 
+#define _DTWI0_SDA_PIN  1
 
+
+#if defined(__32MX795F512H__)
+#define	_DTWI1_BASE		_I2C5_BASE_ADDRESS
+#define	_DTWI1_BUS_IRQ	_I2C5_BUS_IRQ
+#define	_DTWI1_VECTOR	_I2C_5_VECTOR
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  29 
+#define _DTWI1_SDA_PIN  28
+#else
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
-#define	_DTWI1_IPL		_I2C2_IPL_IPC
-#define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  29 
+#define _DTWI1_SDA_PIN  28
+#endif
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Fubarino_SDZ/Board_Defs.h
+++ b/hardware/pic32/variants/Fubarino_SDZ/Board_Defs.h
@@ -336,9 +336,9 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define	_SER0_BASE      _UART4_BASE_ADDRESS
 #define	_SER0_IRQ       _UART4_FAULT_VECTOR
 #define	_SER0_VECTOR    _UART4_FAULT_VECTOR
-#define	_SER0_IPL_ISR   _UART4_IPL_ISR
-#define	_SER0_IPL       _UART4_IPL_IPC
-#define	_SER0_SPL       _UART4_SPL_IPC
+#define	_SER0_IPL_ISR   IPL2SRS
+#define	_SER0_IPL       2
+#define	_SER0_SPL       0
 #define _SER0_TX_OUT    PPS_OUT_U4TX     // (RPF8R = 0b0010)   RF8 -> U4TX   
 #define _SER0_TX_PIN    1                // REBIRDY2/RPF8/SCL3/RF8   
 #define _SER0_RX_IN     PPS_IN_U4RX      // (U4RXR = 0b1011)    RPF2 -> U4RX
@@ -349,9 +349,9 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define	_SER1_BASE		_UART1_BASE_ADDRESS
 #define	_SER1_IRQ		_UART1_FAULT_VECTOR
 #define	_SER1_VECTOR	_UART1_FAULT_VECTOR
-#define	_SER1_IPL_ISR	_UART1_IPL_ISR
-#define	_SER1_IPL		_UART1_IPL_IPC
-#define	_SER1_SPL		_UART1_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SRS
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 #define _SER1_TX_OUT    PPS_OUT_U1TX     // (RPF8R = 0b0010)   RF8 -> U4TX   
 #define _SER1_TX_PIN    40                // REBIRDY2/RPF8/SCL3/RF8   
 #define _SER1_RX_IN     PPS_IN_U1RX      // (U4RXR = 0b1011)    RPF2 -> U4RX
@@ -369,9 +369,9 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define	_SPI_RX_IRQ		_SPI2_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI2_TX_IRQ
 #define	_SPI_VECTOR		_SPI_2_VECTOR
-#define _SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define _SPI_IPL_ISR	IPL3SRS
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* SPI pin declarations
 */
@@ -390,9 +390,9 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define _DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define _DSPI0_IPL_ISR		IPL3SRS
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 #define _DSPI0_MISO_IN		PPS_IN_SDI2
 #define _DSPI0_MISO_PIN		MISO		    // RA1  SDI1    SDI1R = RPA1 = 0 
@@ -406,9 +406,9 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define	_DSPI1_RX_IRQ		_SPI1_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI1_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_1_VECTOR
-#define _DSPI1_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI1_IPL			_SPI1_IPL_IPC
-#define	_DSPI1_SPL			_SPI1_SPL_IPC
+#define _DSPI1_IPL_ISR		IPL3SRS
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 #define _DSPI1_MISO_IN		PPS_IN_SDI1
 #define _DSPI1_MISO_PIN		36		        // RA1  SDI1    SDI1R = RPA1 = 0 
@@ -421,9 +421,9 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define	_DSPI2_RX_IRQ		_SPI3_RX_IRQ
 #define	_DSPI2_TX_IRQ		_SPI3_TX_IRQ
 #define	_DSPI2_VECTOR		_SPI_3_VECTOR
-#define _DSPI2_IPL_ISR		_SPI3_IPL_ISR
-#define	_DSPI2_IPL			_SPI3_IPL_IPC
-#define	_DSPI2_SPL			_SPI3_SPL_IPC
+#define _DSPI2_IPL_ISR		IPL3SRS
+#define	_DSPI2_IPL			3
+#define	_DSPI2_SPL			0
 
 #define _DSPI2_MISO_IN		PPS_IN_SDI3
 #define _DSPI2_MISO_PIN		53		    // RA1  SDI1    SDI1R = RPA1 = 0 
@@ -436,9 +436,9 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define	_DSPI3_RX_IRQ		_SPI4_RX_IRQ
 #define	_DSPI3_TX_IRQ		_SPI4_TX_IRQ
 #define	_DSPI3_VECTOR		_SPI_4_VECTOR
-#define _DSPI3_IPL_ISR		_SPI4_IPL_ISR
-#define	_DSPI3_IPL			_SPI4_IPL_IPC
-#define	_DSPI3_SPL			_SPI4_SPL_IPC
+#define _DSPI3_IPL_ISR		IPL3SRS
+#define	_DSPI3_IPL			3
+#define	_DSPI3_SPL			0
 
 #define _DSPI3_MISO_IN		PPS_IN_SDI2
 #define _DSPI3_MISO_PIN		57		    // RA1  SDI1    SDI1R = RPA1 = 0 
@@ -450,31 +450,30 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 /*					I2C Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard I2C port uses I2C1 (SCL1/SDA1). These come to pins
-** A4/A5 pins 18/19 on the analog connector. It is necessary to have jumpers
-** JP6/JP8 set appropriately (RG2/RG3 position) to access the I2C
-** signals.  
+/* The standard I2C port uses I2C4 (SCL4/SDA4). These come to pins
+** A4/A5 pins 18/19 on the analog connector.
 */
-#define	_TWI_BASE		_I2C4_BASE_ADDRESS
-#define	_TWI_BUS_IRQ	_I2C4_BUS_IRQ
-#define	_TWI_SLV_IRQ	_I2C4_SLAVE_IRQ
-#define	_TWI_MST_IRQ	_I2C4_MASTER_IRQ
-#define	_TWI_VECTOR		_I2C_4_VECTOR
-#define _TWI_IPL_ISR	_I2C4_IPL_ISR
-#define _TWI_IPL		_I2C4_IPL_IPC
-#define	_TWI_SPL		_I2C4_SPL_IPC
+#define	_TWI_BASE		((uint32_t) &I2C4CON)
+#define	_TWI_BUS_IRQ	_I2C4_BUS_VECTOR
+#define	_TWI_SLV_IRQ	_I2C4_SLAVE_VECTOR
+#define	_TWI_MST_IRQ	_I2C4_MASTER_VECTOR
+#define	_TWI_VECTOR		_I2C4_BUS_VECTOR
+#define _TWI_IPL_ISR	IPL3SRS
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
 **		DTWI0 is SDA2/SCL2 on A4/A5 pins 18/19 (see above comment).
 */
-#define	_DTWI0_BASE		_I2C4_BASE_ADDRESS
-#define	_DTWI0_BUS_IRQ	_I2C4_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C4_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C4_MASTER_IRQ
-#define	_DTWI0_VECTOR	_I2C_4_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C4_IPL_ISR
-#define	_DTWI0_IPL		_I2C4_IPL_IPC
-#define	_DTWI0_SPL		_I2C4_SPL_IPC
+
+#define	_DTWI0_BASE		((uint32_t) &I2C4CON)
+#define	_DTWI0_BUS_IRQ	_I2C4_BUS_VECTOR
+#define	_DTWI0_VECTOR	_I2C4_BUS_VECTOR
+#define	_DTWI0_IPL_ISR	IPL3SRS 
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  19 
+#define _DTWI0_SDA_PIN  18
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Max32/Board_Defs.h
+++ b/hardware/pic32/variants/Max32/Board_Defs.h
@@ -291,36 +291,36 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define _SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define _SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART4 (aka UART1B)
 */
 #define	_SER1_BASE		_UART4_BASE_ADDRESS
 #define	_SER1_IRQ		_UART4_ERR_IRQ
 #define	_SER1_VECTOR	_UART_4_VECTOR
-#define _SER1_IPL_ISR	_UART4_IPL_ISR
-#define	_SER1_IPL		_UART4_IPL_IPC
-#define	_SER1_SPL		_UART4_SPL_IPC
+#define _SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* Serial port 2 uses UART2 (aka UART3A)
 */
 #define	_SER2_BASE		_UART2_BASE_ADDRESS
 #define	_SER2_IRQ		_UART2_ERR_IRQ
 #define	_SER2_VECTOR	_UART_2_VECTOR
-#define _SER2_IPL_ISR	_UART2_IPL_ISR
-#define	_SER2_IPL		_UART2_IPL_IPC
-#define	_SER2_SPL		_UART2_SPL_IPC
+#define _SER2_IPL_ISR	IPL2SOFT
+#define	_SER2_IPL		2
+#define	_SER2_SPL		0
 
 /* Serial port 3 uses UART5 (aka UART3B)
 */
 #define	_SER3_BASE		_UART5_BASE_ADDRESS
 #define	_SER3_IRQ		_UART5_ERR_IRQ
 #define	_SER3_VECTOR	_UART_5_VECTOR
-#define _SER3_IPL_ISR	_UART5_IPL_ISR
-#define	_SER3_IPL		_UART5_IPL_IPC
-#define	_SER3_SPL		_UART5_SPL_IPC
+#define _SER3_IPL_ISR	IPL2SOFT
+#define	_SER3_IPL		2
+#define	_SER3_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -402,48 +402,49 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
 #define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
 #define	_DTWI0_IPL		_I2C1_IPL_IPC
 #define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define _DTWI0_SCL_PIN  21 
+#define _DTWI0_SDA_PIN  20
 
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
 #define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
 #define	_DTWI1_IPL		_I2C2_IPL_IPC
 #define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define _DTWI1_SCL_PIN  12 
+#define _DTWI1_SDA_PIN  13
 
 #define	_DTWI2_BASE		_I2C3_BASE_ADDRESS
 #define	_DTWI2_BUS_IRQ	_I2C3_BUS_IRQ
-#define	_DTWI2_SLV_IRQ	_I2C3_SLAVE_IRQ
-#define	_DTWI2_MST_IRQ	_I2C3_MASTER_IRQ
 #define	_DTWI2_VECTOR	_I2C_3_VECTOR
 #define	_DTWI2_IPL_ISR	_I2C3_IPL_ISR
 #define	_DTWI2_IPL		_I2C3_IPL_IPC
 #define	_DTWI2_SPL		_I2C3_SPL_IPC
+#define _DTWI2_SCL_PIN  1 
+#define _DTWI2_SDA_PIN  0
 
 #define	_DTWI3_BASE		_I2C4_BASE_ADDRESS
 #define	_DTWI3_BUS_IRQ	_I2C4_BUS_IRQ
-#define	_DTWI3_SLV_IRQ	_I2C4_SLAVE_IRQ
-#define	_DTWI3_MST_IRQ	_I2C4_MASTER_IRQ
 #define	_DTWI3_VECTOR	_I2C_4_VECTOR
 #define	_DTWI3_IPL_ISR	_I2C4_IPL_ISR
 #define	_DTWI3_IPL		_I2C4_IPL_IPC
 #define	_DTWI3_SPL		_I2C4_SPL_IPC
+#define _DTWI3_SCL_PIN  43 
+#define _DTWI3_SDA_PIN  29
 
 #define	_DTWI4_BASE		_I2C5_BASE_ADDRESS
 #define	_DTWI4_BUS_IRQ	_I2C5_BUS_IRQ
-#define	_DTWI4_SLV_IRQ	_I2C5_SLAVE_IRQ
-#define	_DTWI4_MST_IRQ	_I2C5_MASTER_IRQ
 #define	_DTWI4_VECTOR	_I2C_5_VECTOR
 #define	_DTWI4_IPL_ISR	_I2C5_IPL_ISR
 #define	_DTWI4_IPL		_I2C5_IPL_IPC
 #define	_DTWI4_SPL		_I2C5_SPL_IPC
+#define _DTWI4_SCL_PIN  16 
+#define _DTWI4_SDA_PIN  17
+
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Olimex_PIC32_Pinguino/Board_Defs.h
+++ b/hardware/pic32/variants/Olimex_PIC32_Pinguino/Board_Defs.h
@@ -305,9 +305,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 //#define>_SER0_RX_PIN    8$
 //#define>_SER0_TX_PIN    9$
 
@@ -318,9 +318,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 //#define>_SER0_RX_PIN    28$
 //#define>_SER0_TX_PIN    29$
 
@@ -339,9 +339,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SPI_RX_IRQ		_SPI2_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI2_TX_IRQ
 #define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define	_SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses the same port.
 */
@@ -350,9 +350,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define	_DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define	_DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -368,29 +368,31 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define	_TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define	_TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
-**		DTWI0 is on A4/A5 (see above comment).
-**		DTWI1 is on digital pins 38 & 39.
+**		DTWI0 is on digital pins 15/16
+**		DTWI1 is on digital pins 18/19
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  16 
+#define _DTWI0_SDA_PIN  15
 
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
-#define	_DTWI1_IPL		_I2C2_IPL_IPC
-#define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  19 
+#define _DTWI1_SDA_PIN  18
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Uno32/Board_Defs.h
+++ b/hardware/pic32/variants/Uno32/Board_Defs.h
@@ -294,18 +294,18 @@ extern const uint32_t   digital_pin_to_cn_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART2
 */
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -318,9 +318,9 @@ extern const uint32_t   digital_pin_to_cn_PGM[];
 #define	_SPI_RX_IRQ		_SPI2_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI2_TX_IRQ
 #define	_SPI_VECTOR		_SPI_2_VECTOR
-#define _SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define _SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses these ports.
 */
@@ -329,18 +329,18 @@ extern const uint32_t   digital_pin_to_cn_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define _DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define _DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 #define	_DSPI1_BASE			_SPI1_BASE_ADDRESS
 #define	_DSPI1_ERR_IRQ		_SPI1_ERR_IRQ
 #define	_DSPI1_RX_IRQ		_SPI1_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI1_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_1_VECTOR
-#define _DSPI1_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI1_IPL			_SPI1_IPL_IPC
-#define	_DSPI1_SPL			_SPI1_SPL_IPC
+#define _DSPI1_IPL_ISR		IPL3SOFT
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -356,31 +356,31 @@ extern const uint32_t   digital_pin_to_cn_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define _TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define _TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
 **		DTWI0 is on A4/A5 (see above comment).
-**		DTWI1 is on digital pins 38 & 39.
+**		DTWI1 is on digital pins 40 & 39.
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  46 
+#define _DTWI0_SDA_PIN  45
 
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI1_IPL		_I2C2_IPL_IPC
-#define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  40 
+#define _DTWI1_SDA_PIN  39
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/Uno32_Pmod_Shield/Board_Defs.h
+++ b/hardware/pic32/variants/Uno32_Pmod_Shield/Board_Defs.h
@@ -284,18 +284,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART2
 */
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -308,9 +308,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SPI_RX_IRQ		_SPI2_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI2_TX_IRQ
 #define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define	_SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses these ports.
 **		DSPI0	connector JE
@@ -321,18 +321,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define	_DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define	_DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 #define	_DSPI1_BASE			_SPI1_BASE_ADDRESS
 #define	_DSPI1_ERR_IRQ		_SPI1_ERR_IRQ
 #define	_DSPI1_RX_IRQ		_SPI1_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI1_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_1_VECTOR
-#define	_DSPI1_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI1_IPL			_SPI1_IPL_IPC
-#define	_DSPI1_SPL			_SPI1_SPL_IPC
+#define	_DSPI1_IPL_ISR		IPL3SOFT
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -345,9 +345,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define	_TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define	_TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
 **		DTWI0 is on connector J2
@@ -355,21 +355,21 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  46 
+#define _DTWI0_SDA_PIN  45
 
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI1_IPL		_I2C2_IPL_IPC
-#define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  40 
+#define _DTWI1_SDA_PIN  39
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/WF32/Board_Defs.h
+++ b/hardware/pic32/variants/WF32/Board_Defs.h
@@ -298,27 +298,27 @@ extern const uint8_t 	digital_pin_to_analog_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART4; this goes to pins 39&40
 */
 #define	_SER1_BASE		_UART4_BASE_ADDRESS
 #define	_SER1_IRQ		_UART4_ERR_IRQ
 #define	_SER1_VECTOR	_UART_4_VECTOR
-#define	_SER1_IPL_ISR	_UART4_IPL_ISR
-#define	_SER1_IPL		_UART4_IPL_IPC
-#define	_SER1_SPL		_UART4_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* Serial port 2 uses UART3
 */
 #define	_SER2_BASE		_UART3_BASE_ADDRESS
 #define	_SER2_IRQ		_UART3_ERR_IRQ
 #define	_SER2_VECTOR	_UART_3_VECTOR
-#define	_SER2_IPL_ISR	_UART3_IPL_ISR
-#define	_SER2_IPL		_UART3_IPL_IPC
-#define	_SER2_SPL		_UART3_SPL_IPC
+#define	_SER2_IPL_ISR	IPL2SOFT
+#define	_SER2_IPL		2
+#define	_SER2_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -331,9 +331,9 @@ extern const uint8_t 	digital_pin_to_analog_PGM[];
 #define	_SPI_RX_IRQ		_SPI2_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI2_TX_IRQ
 #define	_SPI_VECTOR		_SPI_2_VECTOR
-#define _SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define _SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses these ports.
 */
@@ -342,27 +342,27 @@ extern const uint8_t 	digital_pin_to_analog_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define _DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define _DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 #define	_DSPI1_BASE			_SPI1_BASE_ADDRESS
 #define	_DSPI1_ERR_IRQ		_SPI1_ERR_IRQ
 #define	_DSPI1_RX_IRQ		_SPI1_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI1_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_1_VECTOR
-#define _DSPI1_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI1_IPL			_SPI1_IPL_IPC
-#define	_DSPI1_SPL			_SPI1_SPL_IPC
+#define _DSPI1_IPL_ISR		IPL3SOFT
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 #define	_DSPI2_BASE			_SPI3_BASE_ADDRESS
 #define	_DSPI2_ERR_IRQ		_SPI3_ERR_IRQ
 #define	_DSPI2_RX_IRQ		_SPI3_RX_IRQ
 #define	_DSPI2_TX_IRQ		_SPI3_TX_IRQ
 #define	_DSPI2_VECTOR		_SPI_3_VECTOR
-#define _DSPI2_IPL_ISR		_SPI3_IPL_ISR
-#define	_DSPI2_IPL			_SPI3_IPL_IPC
-#define	_DSPI2_SPL			_SPI3_SPL_IPC
+#define _DSPI2_IPL_ISR		IPL3SOFT
+#define	_DSPI2_IPL			3
+#define	_DSPI2_SPL			0
 
 // this is the MRF24
 #define	_DSPI3_BASE			_SPI4_BASE_ADDRESS
@@ -370,9 +370,9 @@ extern const uint8_t 	digital_pin_to_analog_PGM[];
 #define	_DSPI3_RX_IRQ		_SPI4_RX_IRQ
 #define	_DSPI3_TX_IRQ		_SPI4_TX_IRQ
 #define	_DSPI3_VECTOR		_SPI_4_VECTOR
-#define _DSPI3_IPL_ISR		_SPI4_IPL_ISR
-#define	_DSPI3_IPL			_SPI4_IPL_IPC
-#define	_DSPI3_SPL			_SPI4_SPL_IPC
+#define _DSPI3_IPL_ISR		IPL3SOFT
+#define	_DSPI3_IPL			3
+#define	_DSPI3_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -388,41 +388,41 @@ extern const uint8_t 	digital_pin_to_analog_PGM[];
 #define	_TWI_SLV_IRQ	_I2C2_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_2_VECTOR
-#define _TWI_IPL_ISR	_I2C2_IPL_ISR
-#define _TWI_IPL		_I2C2_IPL_IPC
-#define	_TWI_SPL		_I2C2_SPL_IPC
+#define _TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
-**		DTWI0 is SDA2/SCL2 on A4/A5 pins 18/19 (see above comment).
+**		DTWI0 is SDA2/SCL2 on A4/A5 pins 18/19 via shared pins 45/46 (see above comment).
 **		DTWI1 is SDA3/SCL3 on on digital pins 0 & 1.
 **		DTWI1 is SDA4/SCL4 on on digital pins 12 & 11.
 */
 #define	_DTWI0_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_2_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI0_IPL		_I2C2_IPL_IPC
-#define	_DTWI0_SPL		_I2C2_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  45 
+#define _DTWI0_SDA_PIN  46
 
 #define	_DTWI1_BASE		_I2C3_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C3_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C3_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C3_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_3_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C3_IPL_ISR
-#define	_DTWI1_IPL		_I2C3_IPL_IPC
-#define	_DTWI1_SPL		_I2C3_SPL_IPC
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  1 
+#define _DTWI1_SDA_PIN  0
 
 #define	_DTWI2_BASE		_I2C4_BASE_ADDRESS
 #define	_DTWI2_BUS_IRQ	_I2C4_BUS_IRQ
-#define	_DTWI2_SLV_IRQ	_I2C4_SLAVE_IRQ
-#define	_DTWI2_MST_IRQ	_I2C4_MASTER_IRQ
 #define	_DTWI2_VECTOR	_I2C_4_VECTOR
-#define	_DTWI2_IPL_ISR	_I2C4_IPL_ISR
-#define	_DTWI2_IPL		_I2C4_IPL_IPC
-#define	_DTWI2_SPL		_I2C4_SPL_IPC
+#define	_DTWI2_IPL_ISR	IPL3SOFT
+#define	_DTWI2_IPL		3
+#define	_DTWI2_SPL		0
+#define _DTWI2_SCL_PIN  11 
+#define _DTWI2_SDA_PIN  12
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/WiFire/Board_Defs.h
+++ b/hardware/pic32/variants/WiFire/Board_Defs.h
@@ -23,7 +23,7 @@
 /*	11/28/2011(GeneA): Moved data definitions and configuration			*/
 /*		functions to Board_Data.c										*/
 /*	11/29/2011(GeneA): Moved int priority definitions to System_Defs.h	*/
-//*	Feb 17, 2012	<KeithV> Added PPS support for MZ devices
+/*	Feb 17, 2012	<KeithV> Added PPS support for MZ devices           */
 /*																		*/
 /************************************************************************/
 //*	This library is free software; you can redistribute it and/or
@@ -46,6 +46,11 @@
 #define BOARD_DEFS_H
 
 #include <inttypes.h>
+
+    #define  _OCMP1_BASE_ADDRESS ((uint32_t) &OC1CON)
+    #define  _TIMER_1_IRQ _TIMER_1_VECTOR
+
+
 
 /* ------------------------------------------------------------ */
 /*				Public Board Declarations						*/
@@ -70,7 +75,7 @@
 #define	NUM_I2C_PORTS		1   
 
 #define NUM_DSPI_PORTS		4
-#define	NUM_DTWI_PORTS		1
+#define	NUM_DTWI_PORTS		2
 
 /* Define I/O devices on the board.
 */
@@ -333,12 +338,12 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 
 /* Serial port 0 uses UART1
 */
-#define	_SER0_BASE      _UART4_BASE_ADDRESS
+#define	_SER0_BASE      ((uint32_t) &U4MODE)
 #define	_SER0_IRQ       _UART4_FAULT_VECTOR
 #define	_SER0_VECTOR    _UART4_FAULT_VECTOR
-#define	_SER0_IPL_ISR   _UART4_IPL_ISR
-#define	_SER0_IPL       _UART4_IPL_IPC
-#define	_SER0_SPL       _UART4_SPL_IPC
+#define	_SER0_IPL_ISR   IPL2SRS
+#define	_SER0_IPL       2
+#define	_SER0_SPL       0
 #define _SER0_TX_OUT    PPS_OUT_U4TX     // (RPF8R = 0b0010)   RF8 -> U4TX   
 #define _SER0_TX_PIN    1                // REBIRDY2/RPF8/SCL3/RF8   
 #define _SER0_RX_IN     PPS_IN_U4RX      // (U4RXR = 0b1011)    RPF2 -> U4RX
@@ -346,12 +351,12 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 
 /* Serial port 1 uses UART1; this goes to pins 39&40
 */
-#define	_SER1_BASE		_UART1_BASE_ADDRESS
+#define	_SER1_BASE		((uint32_t) &U1MODE)
 #define	_SER1_IRQ		_UART1_FAULT_VECTOR
 #define	_SER1_VECTOR	_UART1_FAULT_VECTOR
-#define	_SER1_IPL_ISR	_UART1_IPL_ISR
-#define	_SER1_IPL		_UART1_IPL_IPC
-#define	_SER1_SPL		_UART1_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SRS
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 #define _SER1_TX_OUT    PPS_OUT_U1TX     // (RPF8R = 0b0010)   RF8 -> U4TX   
 #define _SER1_TX_PIN    40                // REBIRDY2/RPF8/SCL3/RF8   
 #define _SER1_RX_IN     PPS_IN_U1RX      // (U4RXR = 0b1011)    RPF2 -> U4RX
@@ -364,14 +369,14 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 
 /* The standard SPI port uses SPI2.
 */
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
+#define	_SPI_BASE		((uint32_t) &SPI2CON)
 #define _SPI_ERR_IRQ	_SPI2_FAULT_VECTOR
 #define	_SPI_RX_IRQ		_SPI2_RX_VECTOR
 #define	_SPI_TX_IRQ		_SPI2_TX_VECTOR
 #define	_SPI_VECTOR		_SPI2_FAULT_VECTOR
-#define _SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define _SPI_IPL_ISR	IPL3SRS
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* SPI pin declarations
 */
@@ -385,14 +390,14 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 */
 
 // same as the default SPI port
-#define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
+#define	_DSPI0_BASE			((uint32_t) &SPI2CON)
 #define	_DSPI0_ERR_IRQ		_SPI2_FAULT_VECTOR
 #define	_DSPI0_RX_IRQ		_SPI2_RX_VECTOR
 #define	_DSPI0_TX_IRQ		_SPI2_TX_VECTOR
 #define	_DSPI0_VECTOR		_SPI2_FAULT_VECTOR
-#define _DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define _DSPI0_IPL_ISR		IPL3SRS
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 #define _DSPI0_MISO_IN		PPS_IN_SDI2
 #define _DSPI0_MISO_PIN		MISO		    // RA1  SDI1    SDI1R = RPA1 = 0 
@@ -401,14 +406,14 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 
 
 // 2nd SPI
-#define	_DSPI1_BASE			_SPI1_BASE_ADDRESS
+#define	_DSPI1_BASE			((uint32_t) &SPI1CON)
 #define	_DSPI1_ERR_IRQ		_SPI1_FAULT_VECTOR
 #define	_DSPI1_RX_IRQ		_SPI1_RX_VECTOR
 #define	_DSPI1_TX_IRQ		_SPI1_TX_VECTOR
 #define	_DSPI1_VECTOR		_SPI1_FAULT_VECTOR
-#define _DSPI1_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI1_IPL			_SPI1_IPL_IPC
-#define	_DSPI1_SPL			_SPI1_SPL_IPC
+#define _DSPI1_IPL_ISR		IPL3SRS
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 #define _DSPI1_MISO_IN		PPS_IN_SDI1
 #define _DSPI1_MISO_PIN		36		        // RA1  SDI1    SDI1R = RPA1 = 0 
@@ -416,14 +421,14 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define _DSPI1_MOSI_PIN		35		        // RA4  SDO1    RPA4R = SDO1 = 3
 
 // SD Card
-#define	_DSPI2_BASE			_SPI3_BASE_ADDRESS
+#define	_DSPI2_BASE			((uint32_t) &SPI3CON)
 #define	_DSPI2_ERR_IRQ		_SPI3_FAULT_VECTOR
 #define	_DSPI2_RX_IRQ		_SPI3_RX_VECTOR
 #define	_DSPI2_TX_IRQ		_SPI3_TX_VECTOR
 #define	_DSPI2_VECTOR		_SPI3_FAULT_VECTOR
-#define _DSPI2_IPL_ISR		_SPI3_IPL_ISR
-#define	_DSPI2_IPL			_SPI3_IPL_IPC
-#define	_DSPI2_SPL			_SPI3_SPL_IPC
+#define _DSPI2_IPL_ISR		IPL3SRS
+#define	_DSPI2_IPL			3
+#define	_DSPI2_SPL			0
 
 #define _DSPI2_MISO_IN		PPS_IN_SDI3
 #define _DSPI2_MISO_PIN		53		    // RA1  SDI1    SDI1R = RPA1 = 0 
@@ -431,14 +436,14 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define _DSPI2_MOSI_PIN		54		    // RA4  SDO1    RPA4R = SDO1 = 3
 
 // this is the MRF24
-#define	_DSPI3_BASE			_SPI4_BASE_ADDRESS
+#define	_DSPI3_BASE			((uint32_t) &SPI4CON)
 #define	_DSPI3_ERR_IRQ		_SPI4_FAULT_VECTOR
 #define	_DSPI3_RX_IRQ		_SPI4_RX_VECTOR
 #define	_DSPI3_TX_IRQ		_SPI4_TX_VECTOR
 #define	_DSPI3_VECTOR		_SPI4_FAULT_VECTOR
-#define _DSPI3_IPL_ISR		_SPI4_IPL_ISR
-#define	_DSPI3_IPL			_SPI4_IPL_IPC
-#define	_DSPI3_SPL			_SPI4_SPL_IPC
+#define _DSPI3_IPL_ISR		IPL3SRS
+#define	_DSPI3_IPL			3
+#define	_DSPI3_SPL			0
 
 #define _DSPI3_MISO_IN		PPS_IN_SDI2
 #define _DSPI3_MISO_PIN		57		    // RA1  SDI1    SDI1R = RPA1 = 0 
@@ -450,31 +455,39 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 /*					I2C Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard I2C port uses I2C1 (SCL1/SDA1). These come to pins
-** A4/A5 pins 18/19 on the analog connector. It is necessary to have jumpers
-** JP6/JP8 set appropriately (RG2/RG3 position) to access the I2C
-** signals.  
+/* The standard I2C port uses I2C4 (SCL4/SDA4). These come to pins
+** A4/A5 pins 18/19 on the analog connector.
 */
-#define	_TWI_BASE		_I2C4_BASE_ADDRESS
-#define	_TWI_BUS_IRQ	_I2C4_BUS_IRQ
-#define	_TWI_SLV_IRQ	_I2C4_SLAVE_IRQ
-#define	_TWI_MST_IRQ	_I2C4_MASTER_IRQ
-#define	_TWI_VECTOR		_I2C_4_VECTOR
-#define _TWI_IPL_ISR	_I2C4_IPL_ISR
-#define _TWI_IPL		_I2C4_IPL_IPC
-#define	_TWI_SPL		_I2C4_SPL_IPC
+#define	_TWI_BASE		((uint32_t) &I2C4CON)
+#define	_TWI_BUS_IRQ	_I2C4_BUS_VECTOR
+#define	_TWI_SLV_IRQ	_I2C4_SLAVE_VECTOR
+#define	_TWI_MST_IRQ	_I2C4_MASTER_VECTOR
+#define	_TWI_VECTOR		_I2C4_BUS_VECTOR
+#define _TWI_IPL_ISR	IPL3SRS
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
 **		DTWI0 is SDA2/SCL2 on A4/A5 pins 18/19 (see above comment).
 */
-#define	_DTWI0_BASE		_I2C4_BASE_ADDRESS
-#define	_DTWI0_BUS_IRQ	_I2C4_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C4_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C4_MASTER_IRQ
-#define	_DTWI0_VECTOR	_I2C_4_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C4_IPL_ISR
-#define	_DTWI0_IPL		_I2C4_IPL_IPC
-#define	_DTWI0_SPL		_I2C4_SPL_IPC
+
+#define	_DTWI0_BASE		((uint32_t) &I2C4CON)
+#define	_DTWI0_BUS_IRQ	_I2C4_BUS_VECTOR
+#define	_DTWI0_VECTOR	_I2C4_BUS_VECTOR
+#define	_DTWI0_IPL_ISR	IPL3SRS 
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  19 
+#define _DTWI0_SDA_PIN  18
+
+#define	_DTWI1_BASE		((uint32_t) &I2C2CON)
+#define	_DTWI1_BUS_IRQ	_I2C2_BUS_VECTOR
+#define	_DTWI1_VECTOR	_I2C2_BUS_VECTOR
+#define	_DTWI1_IPL_ISR	IPL3SRS 
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  37 
+#define _DTWI1_SDA_PIN  4
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/
@@ -491,6 +504,13 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define _PORTE
 #define _PORTF
 #define _PORTG
+
+/* ------------------------------------------------------------ */
+/*  JTAG Support, set to 1 if you want JTAG enabled             */
+/*  otherwise JTAG will be disabled                             */
+/* ------------------------------------------------------------ */
+// Wi-FIRE supports JTAG
+#define _JTAG 1
 
 /* ------------------------------------------------------------ */
 

--- a/hardware/pic32/variants/WiFire/boards.txt
+++ b/hardware/pic32/variants/WiFire/boards.txt
@@ -31,3 +31,36 @@ chipkit_WiFire.build.variant=WiFire
 #chipkit_WiFire.upload.using=avrdude1
 
 ############################################################
+############################################################
+chipkit_WiFire_80MHz.name=chipKIT WiFire 80MHz
+chipkit_WiFire_80MHz.group=chipKIT
+
+
+# new items
+chipkit_WiFire_80MHz.platform=pic32
+chipkit_WiFire_80MHz.board=_BOARD_WIFIRE_
+chipkit_WiFire_80MHz.board.define=
+chipkit_WiFire_80MHz.ccflags=ffff
+chipkit_WiFire_80MHz.ldscript=MZ-application-32MZ2048ECX.ld
+# end of new items
+
+chipkit_WiFire_80MHz.upload.protocol=stk500v2
+chipkit_WiFire_80MHz.upload.maximum_size=520192
+chipkit_WiFire_80MHz.upload.speed=115200
+
+chipkit_WiFire_80MHz.bootloader.low_fuses=0xff
+chipkit_WiFire_80MHz.bootloader.high_fuses=0xdd
+chipkit_WiFire_80MHz.bootloader.extended_fuses=0x00
+chipkit_WiFire_80MHz.bootloader.path=not-supported
+chipkit_WiFire_80MHz.bootloader.file=not-supported
+chipkit_WiFire_80MHz.bootloader.unlock_bits=0x3F
+chipkit_WiFire_80MHz.bootloader.lock_bits=0x0F
+
+chipkit_WiFire_80MHz.build.mcu=32MZ2048ECG100
+chipkit_WiFire_80MHz.build.f_cpu=80000000UL
+chipkit_WiFire_80MHz.build.core=pic32
+chipkit_WiFire_80MHz.ldcommon=chipKIT-application-COMMON-MZ.ld
+chipkit_WiFire_80MHz.build.variant=WiFire
+#chipkit_WiFire_80MHz.upload.using=avrdude1
+
+############################################################

--- a/hardware/pic32/variants/picadillo_35t/Board_Defs.h
+++ b/hardware/pic32/variants/picadillo_35t/Board_Defs.h
@@ -192,25 +192,25 @@ extern const uint8_t    digital_pin_to_analog_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 // Serial port 1 (pins 8 and 10) uses UART4
 #define	_SER1_BASE		_UART4_BASE_ADDRESS
 #define	_SER1_IRQ		_UART4_ERR_IRQ
 #define	_SER1_VECTOR	_UART_4_VECTOR
-#define	_SER1_IPL_ISR	_UART4_IPL_ISR
-#define	_SER1_IPL		_UART4_IPL_IPC
-#define	_SER1_SPL		_UART4_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 // Serial 2 (UART 2) is on the SPI header
 #define	_SER2_BASE		_UART2_BASE_ADDRESS
 #define	_SER2_IRQ		_UART2_ERR_IRQ
 #define	_SER2_VECTOR	_UART_2_VECTOR
-#define	_SER2_IPL_ISR	_UART2_IPL_ISR
-#define	_SER2_IPL		_UART2_IPL_IPC
-#define	_SER2_SPL		_UART2_SPL_IPC
+#define	_SER2_IPL_ISR	IPL2SOFT
+#define	_SER2_IPL		2
+#define	_SER2_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -223,9 +223,9 @@ extern const uint8_t    digital_pin_to_analog_PGM[];
 #define	_SPI_RX_IRQ		_SPI4_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI4_TX_IRQ
 #define	_SPI_VECTOR		_SPI_4_VECTOR
-#define _SPI_IPL_ISR	_SPI4_IPL_ISR
-#define	_SPI_IPL		_SPI4_IPL_IPC
-#define	_SPI_SPL		_SPI4_SPL_IPC
+#define _SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses these ports.
 */
@@ -236,9 +236,9 @@ extern const uint8_t    digital_pin_to_analog_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define _DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define _DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 // DSPI1 is the 6 pin SPI header (SPI4)
 #define	_DSPI1_BASE			_SPI4_BASE_ADDRESS
@@ -246,9 +246,9 @@ extern const uint8_t    digital_pin_to_analog_PGM[];
 #define	_DSPI1_RX_IRQ		_SPI4_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI4_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_4_VECTOR
-#define _DSPI1_IPL_ISR		_SPI4_IPL_ISR
-#define	_DSPI1_IPL			_SPI4_IPL_IPC
-#define	_DSPI1_SPL			_SPI4_SPL_IPC
+#define _DSPI1_IPL_ISR		IPL3SOFT
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 // DSPI2 is the pins 11-13 SPI interface (SPI1)
 #define	_DSPI2_BASE			_SPI1_BASE_ADDRESS
@@ -256,9 +256,9 @@ extern const uint8_t    digital_pin_to_analog_PGM[];
 #define	_DSPI2_RX_IRQ		_SPI1_RX_IRQ
 #define	_DSPI2_TX_IRQ		_SPI1_TX_IRQ
 #define	_DSPI2_VECTOR		_SPI_1_VECTOR
-#define _DSPI2_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI2_IPL			_SPI1_IPL_IPC
-#define	_DSPI2_SPL			_SPI1_SPL_IPC
+#define _DSPI2_IPL_ISR		IPL3SOFT
+#define	_DSPI2_IPL			3
+#define	_DSPI2_SPL			0
 
 // DSPI3 is the extra "hidden" SPI port (uses UART pins) (SPI3)
 #define	_DSPI3_BASE			_SPI3_BASE_ADDRESS
@@ -266,9 +266,9 @@ extern const uint8_t    digital_pin_to_analog_PGM[];
 #define	_DSPI3_RX_IRQ		_SPI3_RX_IRQ
 #define	_DSPI3_TX_IRQ		_SPI3_TX_IRQ
 #define	_DSPI3_VECTOR		_SPI_3_VECTOR
-#define _DSPI3_IPL_ISR		_SPI3_IPL_ISR
-#define	_DSPI3_IPL			_SPI3_IPL_IPC
-#define	_DSPI3_SPL			_SPI3_SPL_IPC
+#define _DSPI3_IPL_ISR		IPL3SOFT
+#define	_DSPI3_IPL			3
+#define	_DSPI3_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -284,21 +284,21 @@ extern const uint8_t    digital_pin_to_analog_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define _TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define _TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library. (which doesn't yet exist)
-**		DTWI0 is on A4/A5 (see above comment).
+**		DTWI0 is on digital pins 53/54
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  54 
+#define _DTWI0_SDA_PIN  53
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/quicK240/Board_Defs.h
+++ b/hardware/pic32/variants/quicK240/Board_Defs.h
@@ -348,36 +348,36 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define _SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define _SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART4 (aka UART1B)
 */
 #define	_SER1_BASE		_UART4_BASE_ADDRESS
 #define	_SER1_IRQ		_UART4_ERR_IRQ
 #define	_SER1_VECTOR	_UART_4_VECTOR
-#define _SER1_IPL_ISR	_UART4_IPL_ISR
-#define	_SER1_IPL		_UART4_IPL_IPC
-#define	_SER1_SPL		_UART4_SPL_IPC
+#define _SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* Serial port 2 uses UART2 (aka UART3A)
 */
 #define	_SER2_BASE		_UART2_BASE_ADDRESS
 #define	_SER2_IRQ		_UART2_ERR_IRQ
 #define	_SER2_VECTOR	_UART_2_VECTOR
-#define _SER2_IPL_ISR	_UART2_IPL_ISR
-#define	_SER2_IPL		_UART2_IPL_IPC
-#define	_SER2_SPL		_UART2_SPL_IPC
+#define _SER2_IPL_ISR	IPL2SOFT
+#define	_SER2_IPL		2
+#define	_SER2_SPL		0
 
 /* Serial port 3 uses UART5 (aka UART3B)
 */
 #define	_SER3_BASE		_UART5_BASE_ADDRESS
 #define	_SER3_IRQ		_UART5_ERR_IRQ
 #define	_SER3_VECTOR	_UART_5_VECTOR
-#define _SER3_IPL_ISR	_UART5_IPL_ISR
-#define	_SER3_IPL		_UART5_IPL_IPC
-#define	_SER3_SPL		_UART5_SPL_IPC
+#define _SER3_IPL_ISR	IPL2SOFT
+#define	_SER3_IPL		2
+#define	_SER3_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -390,9 +390,9 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 #define	_SPI_RX_IRQ		_SPI1_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI1_TX_IRQ
 #define	_SPI_VECTOR		_SPI_1_VECTOR
-#define	_SPI_IPL_ISR	_SPI1_IPL_ISR
-#define	_SPI_IPL		_SPI1_IPL_IPC
-#define	_SPI_SPL		_SPI1_SPL_IPC
+#define	_SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses these ports.
 */
@@ -401,18 +401,18 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define	_DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define	_DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 #define	_DSPI1_BASE			_SPI1_BASE_ADDRESS
 #define	_DSPI1_ERR_IRQ		_SPI1_ERR_IRQ
 #define	_DSPI1_RX_IRQ		_SPI1_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI1_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_1_VECTOR
-#define	_DSPI1_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI1_IPL			_SPI1_IPL_IPC
-#define	_DSPI1_SPL			_SPI1_SPL_IPC
+#define	_DSPI1_IPL_ISR		IPL3SOFT
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 #define	_SPI3_ERR_IRQ	_SPI1A_ERR_IRQ	//this declaration missing from the
 										//Microchip header file
@@ -421,18 +421,18 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 #define	_DSPI2_RX_IRQ		_SPI3_RX_IRQ
 #define	_DSPI2_TX_IRQ		_SPI3_TX_IRQ
 #define	_DSPI2_VECTOR		_SPI_3_VECTOR
-#define	_DSPI2_IPL_ISR		_SPI3_IPL_ISR
-#define	_DSPI2_IPL			_SPI3_IPL_IPC
-#define	_DSPI2_SPL			_SPI3_SPL_IPC
+#define	_DSPI2_IPL_ISR		IPL3SOFT
+#define	_DSPI2_IPL			3
+#define	_DSPI2_SPL			0
 
 #define	_DSPI3_BASE			_SPI4_BASE_ADDRESS
 #define	_DSPI3_ERR_IRQ		_SPI4_ERR_IRQ
 #define	_DSPI3_RX_IRQ		_SPI4_RX_IRQ
 #define	_DSPI3_TX_IRQ		_SPI4_TX_IRQ
 #define	_DSPI3_VECTOR		_SPI_4_VECTOR
-#define	_DSPI3_IPL_ISR		_SPI4_IPL_ISR
-#define	_DSPI3_IPL			_SPI4_IPL_IPC
-#define	_DSPI3_SPL			_SPI4_SPL_IPC
+#define	_DSPI3_IPL_ISR		IPL3SOFT
+#define	_DSPI3_IPL			3
+#define	_DSPI3_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -446,9 +446,9 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 #define	_TWI_SLV_IRQ	_I2C2_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_2_VECTOR
-#define	_TWI_IPL_ISR	_I2C2_IPL_ISR
-#define _TWI_IPL		_I2C2_IPL_IPC
-#define	_TWI_SPL		_I2C2_SPL_IPC
+#define	_TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
 **		DTWI0:	SDA pin 20, SCL pin 21
@@ -459,48 +459,48 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  21 
+#define _DTWI0_SDA_PIN  20
 
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI1_IPL		_I2C2_IPL_IPC
-#define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  12 
+#define _DTWI1_SDA_PIN  13
 
 #define	_DTWI2_BASE		_I2C3_BASE_ADDRESS
 #define	_DTWI2_BUS_IRQ	_I2C3_BUS_IRQ
-#define	_DTWI2_SLV_IRQ	_I2C3_SLAVE_IRQ
-#define	_DTWI2_MST_IRQ	_I2C3_MASTER_IRQ
 #define	_DTWI2_VECTOR	_I2C_3_VECTOR
-#define	_DTWI2_IPL_ISR	_I2C3_IPL_ISR
-#define	_DTWI2_IPL		_I2C3_IPL_IPC
-#define	_DTWI2_SPL		_I2C3_SPL_IPC
+#define	_DTWI2_IPL_ISR	IPL3SOFT
+#define	_DTWI2_IPL		3
+#define	_DTWI2_SPL		0
+#define _DTWI2_SCL_PIN  1 
+#define _DTWI2_SDA_PIN  0
 
 #define	_DTWI3_BASE		_I2C4_BASE_ADDRESS
 #define	_DTWI3_BUS_IRQ	_I2C4_BUS_IRQ
-#define	_DTWI3_SLV_IRQ	_I2C4_SLAVE_IRQ
-#define	_DTWI3_MST_IRQ	_I2C4_MASTER_IRQ
 #define	_DTWI3_VECTOR	_I2C_4_VECTOR
-#define	_DTWI3_IPL_ISR	_I2C4_IPL_ISR
-#define	_DTWI3_IPL		_I2C4_IPL_IPC
-#define	_DTWI3_SPL		_I2C4_SPL_IPC
+#define	_DTWI3_IPL_ISR	IPL3SOFT
+#define	_DTWI3_IPL		3
+#define	_DTWI3_SPL		0
+#define _DTWI3_SCL_PIN  43 
+#define _DTWI3_SDA_PIN  29
 
 #define	_DTWI4_BASE		_I2C5_BASE_ADDRESS
 #define	_DTWI4_BUS_IRQ	_I2C5_BUS_IRQ
-#define	_DTWI4_SLV_IRQ	_I2C5_SLAVE_IRQ
-#define	_DTWI4_MST_IRQ	_I2C5_MASTER_IRQ
 #define	_DTWI4_VECTOR	_I2C_5_VECTOR
-#define	_DTWI4_IPL_ISR	_I2C5_IPL_ISR
-#define	_DTWI4_IPL		_I2C5_IPL_IPC
-#define	_DTWI4_SPL		_I2C5_SPL_IPC
+#define	_DTWI4_IPL_ISR	IPL3SOFT
+#define	_DTWI4_IPL		3
+#define	_DTWI4_SPL		0
+#define _DTWI4_SCL_PIN  16 
+#define _DTWI4_SDA_PIN  17
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/uC32/Board_Defs.h
+++ b/hardware/pic32/variants/uC32/Board_Defs.h
@@ -279,18 +279,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART2
 */
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -303,9 +303,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SPI_RX_IRQ		_SPI2_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI2_TX_IRQ
 #define	_SPI_VECTOR		_SPI_2_VECTOR
-#define _SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define _SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses these ports.
 */
@@ -314,18 +314,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define _DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define _DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 #define	_DSPI1_BASE			_SPI1_BASE_ADDRESS
 #define	_DSPI1_ERR_IRQ		_SPI1_ERR_IRQ
 #define	_DSPI1_RX_IRQ		_SPI1_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI1_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_1_VECTOR
-#define _DSPI1_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI1_IPL			_SPI1_IPL_IPC
-#define	_DSPI1_SPL			_SPI1_SPL_IPC
+#define _DSPI1_IPL_ISR		IPL3SOFT
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -341,9 +341,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define _TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define _TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
 **		DTWI0 is on A4/A5 (see above comment).
@@ -351,21 +351,21 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  46 
+#define _DTWI0_SDA_PIN  45
 
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI1_IPL		_I2C2_IPL_IPC
-#define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  40 
+#define _DTWI1_SDA_PIN  39
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/

--- a/hardware/pic32/variants/uC32_Pmod_Shield/Board_Defs.h
+++ b/hardware/pic32/variants/uC32_Pmod_Shield/Board_Defs.h
@@ -284,18 +284,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SER0_BASE		_UART1_BASE_ADDRESS
 #define	_SER0_IRQ		_UART1_ERR_IRQ
 #define	_SER0_VECTOR	_UART_1_VECTOR
-#define	_SER0_IPL_ISR	_UART1_IPL_ISR
-#define	_SER0_IPL		_UART1_IPL_IPC
-#define	_SER0_SPL		_UART1_SPL_IPC
+#define	_SER0_IPL_ISR	IPL2SOFT
+#define	_SER0_IPL		2
+#define	_SER0_SPL		0
 
 /* Serial port 1 uses UART2
 */
 #define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_ERR_IRQ
 #define	_SER1_VECTOR	_UART_2_VECTOR
-#define	_SER1_IPL_ISR	_UART2_IPL_ISR
-#define	_SER1_IPL		_UART2_IPL_IPC
-#define	_SER1_SPL		_UART2_SPL_IPC
+#define	_SER1_IPL_ISR	IPL2SOFT
+#define	_SER1_IPL		2
+#define	_SER1_SPL		0
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -308,9 +308,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_SPI_RX_IRQ		_SPI2_RX_IRQ
 #define	_SPI_TX_IRQ		_SPI2_TX_IRQ
 #define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
+#define	_SPI_IPL_ISR	IPL3SOFT
+#define	_SPI_IPL		3
+#define	_SPI_SPL		0
 
 /* The Digilent DSPI library uses these ports.
 **		DSPI0	connector JE
@@ -321,18 +321,18 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DSPI0_RX_IRQ		_SPI2_RX_IRQ
 #define	_DSPI0_TX_IRQ		_SPI2_TX_IRQ
 #define	_DSPI0_VECTOR		_SPI_2_VECTOR
-#define	_DSPI0_IPL_ISR		_SPI2_IPL_ISR
-#define	_DSPI0_IPL			_SPI2_IPL_IPC
-#define	_DSPI0_SPL			_SPI2_SPL_IPC
+#define	_DSPI0_IPL_ISR		IPL3SOFT
+#define	_DSPI0_IPL			3
+#define	_DSPI0_SPL			0
 
 #define	_DSPI1_BASE			_SPI1_BASE_ADDRESS
 #define	_DSPI1_ERR_IRQ		_SPI1_ERR_IRQ
 #define	_DSPI1_RX_IRQ		_SPI1_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI1_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_1_VECTOR
-#define	_DSPI1_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI1_IPL			_SPI1_IPL_IPC
-#define	_DSPI1_SPL			_SPI1_SPL_IPC
+#define	_DSPI1_IPL_ISR		IPL3SOFT
+#define	_DSPI1_IPL			3
+#define	_DSPI1_SPL			0
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -345,9 +345,9 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_TWI_SLV_IRQ	_I2C1_SLAVE_IRQ
 #define	_TWI_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_TWI_VECTOR		_I2C_1_VECTOR
-#define	_TWI_IPL_ISR	_I2C1_IPL_ISR
-#define _TWI_IPL		_I2C1_IPL_IPC
-#define	_TWI_SPL		_I2C1_SPL_IPC
+#define	_TWI_IPL_ISR	IPL3SOFT
+#define _TWI_IPL		3
+#define	_TWI_SPL		0
 
 /* Declarations for Digilent DTWI library.
 **		DTWI0 is on connector J2
@@ -355,21 +355,21 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 */
 #define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_SLV_IRQ	_I2C1_SLAVE_IRQ
-#define	_DTWI0_MST_IRQ	_I2C1_MASTER_IRQ
 #define	_DTWI0_VECTOR	_I2C_1_VECTOR
-#define	_DTWI0_IPL_ISR	_I2C1_IPL_ISR
-#define	_DTWI0_IPL		_I2C1_IPL_IPC
-#define	_DTWI0_SPL		_I2C1_SPL_IPC
+#define	_DTWI0_IPL_ISR	IPL3SOFT
+#define	_DTWI0_IPL		3
+#define	_DTWI0_SPL		0
+#define _DTWI0_SCL_PIN  46 
+#define _DTWI0_SDA_PIN  45
 
 #define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_SLV_IRQ	_I2C2_SLAVE_IRQ
-#define	_DTWI1_MST_IRQ	_I2C2_MASTER_IRQ
 #define	_DTWI1_VECTOR	_I2C_2_VECTOR
-#define	_DTWI1_IPL_ISR	_I2C2_IPL_ISR
-#define	_DTWI1_IPL		_I2C2_IPL_IPC
-#define	_DTWI1_SPL		_I2C2_SPL_IPC
+#define	_DTWI1_IPL_ISR	IPL3SOFT
+#define	_DTWI1_IPL		3
+#define	_DTWI1_SPL		0
+#define _DTWI1_SCL_PIN  40 
+#define _DTWI1_SDA_PIN  39
 
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/


### PR DESCRIPTION
With the new compiler interrupt processing changed and we need to explicitly specify IPLxSOFT or IPLxSRS or nothing at all on the interrupt() attribute for interrupts; specifying just IPLx will cause problems. Also, constructor initialization is now running before the interrupt vector manager is initialized and a default interrupt handler is being installed by the runtime. The interrupt manager initialization now accommodates this and that fixed WIRE on the MX. The MZ has a different I2C hardware implementation and DTWI I2C library was implemented to support both MX and MZ processors. WIRE continues to work for MX, but does not work for MZ, to use I2C on MZ use the DTWI library. Timer now operates at the appropriate 20ms speed for the MZ. An 80MHz version of the WiFIRE is supported in boards.txt, but requires an 80MHz bootloader. I added the standard MCHP peripheral "bits" structures to most of the p32_defs.h peripherals so the code can now use the same bit names as in the MCHP documentation; the old non-standard names are still supported.
