### PR TITLE
update to at_vector interrupts

### DIFF
--- a/hardware/pic32/cores/pic32/HardwareSerial.cpp
+++ b/hardware/pic32/cores/pic32/HardwareSerial.cpp
@@ -204,7 +204,7 @@ void HardwareSerial::begin(unsigned long baudRate)
     mapPps(pinRx, ppsRx);
 #endif
 
-        setIntVector(vec, isr);
+    setIntVector(vec, isr);
 
 	/* Set the interrupt privilege level and sub-privilege level
 	*/
@@ -218,8 +218,8 @@ void HardwareSerial::begin(unsigned long baudRate)
         // the MZ part works off of offset tables
         // we must fill in the tx and rx VECs to point
         // to the ERR VEC so all 3 VECs use the same ISR
-        pISROffset[vec+1] = pISROffset[vec];
-        pISROffset[vec+2] = pISROffset[vec];
+        setIntVector(vec+1, isr);
+        setIntVector(vec+2, isr);
 
         // and set the priorities for the other 2 vectors.
         setIntPriority(vec+1, ipl, spl);
@@ -779,7 +779,7 @@ extern "C" {
 #if defined(_SER0_VECTOR)
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_SER0_VECTOR),interrupt(_SER0_IPL_ISR))) IntSer0Handler(void)
+void __attribute__((nomips16,at_vector(_SER0_VECTOR),interrupt(_SER0_IPL_ISR))) IntSer0Handler(void)
 #else
 void __attribute__((interrupt(), nomips16)) IntSer0Handler(void)
 #endif
@@ -811,7 +811,7 @@ void __attribute__((interrupt(), nomips16)) IntSer0Handler(void)
 #if defined(_SER1_VECTOR)
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_SER1_VECTOR),interrupt(_SER1_IPL_ISR))) IntSer1Handler(void)
+void __attribute__((nomips16,at_vector(_SER1_VECTOR),interrupt(_SER1_IPL_ISR))) IntSer1Handler(void)
 #else
 void __attribute__((interrupt(), nomips16)) IntSer1Handler(void)
 #endif
@@ -839,7 +839,7 @@ void __attribute__((interrupt(), nomips16)) IntSer1Handler(void)
 #if defined(_SER2_VECTOR)
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_SER2_VECTOR),interrupt(_SER2_IPL_ISR))) IntSer2Handler(void)
+void __attribute__((nomips16,at_vector(_SER2_VECTOR),interrupt(_SER2_IPL_ISR))) IntSer2Handler(void)
 #else
 void __attribute__((interrupt(), nomips16)) IntSer2Handler(void)
 #endif
@@ -867,7 +867,7 @@ void __attribute__((interrupt(), nomips16)) IntSer2Handler(void)
 #if defined(_SER3_VECTOR)
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_SER3_VECTOR),interrupt(_SER3_IPL_ISR))) IntSer3Handler(void)
+void __attribute__((nomips16,at_vector(_SER3_VECTOR),interrupt(_SER3_IPL_ISR))) IntSer3Handler(void)
 #else
 void __attribute__((interrupt(), nomips16)) IntSer3Handler(void)
 #endif
@@ -895,7 +895,7 @@ void __attribute__((interrupt(), nomips16)) IntSer3Handler(void)
 #if defined(_SER4_VECTOR)
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_SER4_VECTOR),interrupt(_SER4_IPL_ISR))) IntSer4Handler(void)
+void __attribute__((nomips16,at_vector(_SER4_VECTOR),interrupt(_SER4_IPL_ISR))) IntSer4Handler(void)
 #else
 void __attribute__((interrupt(), nomips16)) IntSer4Handler(void)
 #endif
@@ -923,7 +923,7 @@ void __attribute__((interrupt(), nomips16)) IntSer4Handler(void)
 #if defined(_SER5_VECTOR)
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_SER5_VECTOR),interrupt(_SER5_IPL_ISR))) IntSer5Handler(void)
+void __attribute__((nomips16,at_vector(_SER5_VECTOR),interrupt(_SER5_IPL_ISR))) IntSer5Handler(void)
 #else
  void __attribute__((interrupt(), nomips16)) IntSer5Handler(void)
 #endif
@@ -951,7 +951,7 @@ void __attribute__((nomips16,vector(_SER5_VECTOR),interrupt(_SER5_IPL_ISR))) Int
 #if defined(_SER6_VECTOR)
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_SER6_VECTOR),interrupt(_SER6_IPL_ISR))) IntSer6Handler(void)
+void __attribute__((nomips16,at_vector(_SER6_VECTOR),interrupt(_SER6_IPL_ISR))) IntSer6Handler(void)
 #else
 void __attribute__((interrupt(), nomips16)) IntSer6Handler(void)
 #endif
@@ -979,7 +979,7 @@ void __attribute__((interrupt(), nomips16)) IntSer6Handler(void)
 #if defined(_SER7_VECTOR)
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_SER7_VECTOR),interrupt(_SER7_IPL_ISR))) IntSer7Handler(void)
+void __attribute__((nomips16,at_vector(_SER7_VECTOR),interrupt(_SER7_IPL_ISR))) IntSer7Handler(void)
 #else
 void __attribute__((interrupt(), nomips16)) IntSer7Handler(void)
 #endif

--- a/hardware/pic32/cores/pic32/Tone.cpp
+++ b/hardware/pic32/cores/pic32/Tone.cpp
@@ -171,7 +171,7 @@ extern "C"
 //*	not done yet
 //************************************************************************
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_TIMER_1_VECTOR),interrupt(IPL3SRS))) Timer1Handler(void)
+void __attribute__((nomips16,at_vector(_TIMER_1_VECTOR),interrupt(IPL3SRS))) Timer1Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) Timer1Handler(void)
 #endif

--- a/hardware/pic32/cores/pic32/WInterrupts.c
+++ b/hardware/pic32/cores/pic32/WInterrupts.c
@@ -258,7 +258,7 @@ void detachInterrupt(uint8_t interruptNum)
 //************************************************************************
 // INT0 ISR
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_EXTERNAL_0_VECTOR),interrupt(IPL4SRS))) ExtInt0Handler(void)
+void __attribute__((nomips16,at_vector(_EXTERNAL_0_VECTOR),interrupt(IPL4SRS))) ExtInt0Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) ExtInt0Handler(void)
 #endif
@@ -274,7 +274,7 @@ void __attribute__((interrupt(),nomips16)) ExtInt0Handler(void)
 //************************************************************************
 // INT1 ISR
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_EXTERNAL_1_VECTOR),interrupt(IPL4SRS))) ExtInt1Handler(void)
+void __attribute__((nomips16,at_vector(_EXTERNAL_1_VECTOR),interrupt(IPL4SRS))) ExtInt1Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) ExtInt1Handler(void)
 #endif
@@ -290,7 +290,7 @@ void __attribute__((interrupt(),nomips16)) ExtInt1Handler(void)
 //************************************************************************
 // INT2 ISR
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_EXTERNAL_2_VECTOR),interrupt(IPL4SRS))) ExtInt2Handler(void)
+void __attribute__((nomips16,at_vector(_EXTERNAL_2_VECTOR),interrupt(IPL4SRS))) ExtInt2Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) ExtInt2Handler(void)
 #endif
@@ -306,7 +306,7 @@ void __attribute__((interrupt(),nomips16)) ExtInt2Handler(void)
 //************************************************************************
 // INT3 ISR
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_EXTERNAL_3_VECTOR),interrupt(IPL4SRS))) ExtInt3Handler(void)
+void __attribute__((nomips16,at_vector(_EXTERNAL_3_VECTOR),interrupt(IPL4SRS))) ExtInt3Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) ExtInt3Handler(void)
 #endif
@@ -322,7 +322,7 @@ void __attribute__((interrupt(),nomips16)) ExtInt3Handler(void)
 //************************************************************************
 // INT4 ISR
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_EXTERNAL_4_VECTOR),interrupt(IPL4SRS))) ExtInt4Handler(void)
+void __attribute__((nomips16,at_vector(_EXTERNAL_4_VECTOR),interrupt(IPL4SRS))) ExtInt4Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) ExtInt4Handler(void)
 #endif

--- a/hardware/pic32/cores/pic32/chipKIT-application-COMMON-MZ.ld
+++ b/hardware/pic32/cores/pic32/chipKIT-application-COMMON-MZ.ld
@@ -97,8 +97,20 @@ SECTIONS
     KEEP(*(.gen_handler))
   } > kseg0_vector_mem
 
+  /*  The startup code is in the .reset.startup section.
+   *  Keep this here for backwards compatibility with older
+   *  C32 v1.xx releases.
+   */
+
+  /* Boot Sections */
+  .reset _RESET_ADDR :
+  {
+    KEEP(*(.reset))
+    KEEP(*(.reset.startup))
+  } > kseg0_program_mem
+
   /* Interrupt vector table with vector offsets */
-  .vectors _ebase_address + 0x200 :
+  .vectors  :
   {
     _vector_0_addr = . ;
     /*  Symbol __vector_offset_n points to .vector_n if it exists,
@@ -622,18 +634,16 @@ SECTIONS
     /* Default interrupt handler */
     __vector_offset_default = . - _ebase_address;
     KEEP(*(.vector_default))
-  } > kseg0_vector_mem
+  } > kseg0_program_mem
 
-  /*  The startup code is in the .reset.startup section.
-   *  Keep this here for backwards compatibility with older
-   *  C32 v1.xx releases.
-   */
-
-  /* Boot Sections */
-  .reset _RESET_ADDR :
+  /* user interrupt is for user defined interrupts that
+  ** that will be dynamically assigned at runtime
+  ** This will force the code to be placed within 2^^18 of EBASE
+  ** so the function can be put in the OFFxxx register and work
+  */
+  .user_interrupt :
   {
-    KEEP(*(.reset))
-    KEEP(*(.reset.startup))
+    KEEP(*(.user_interrupt))
   } > kseg0_program_mem
 
   .startup :

--- a/hardware/pic32/cores/pic32/wiring.c
+++ b/hardware/pic32/cores/pic32/wiring.c
@@ -715,7 +715,7 @@ uint32_t millisecondCoreTimerService(uint32_t curTime)
 **
 */
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16, vector(_CORE_TIMER_VECTOR),interrupt(IPL7SRS))) CoreTimerHandler(void)
+void __attribute__((nomips16, at_vector(_CORE_TIMER_VECTOR),interrupt(IPL7SRS))) CoreTimerHandler(void)
 #else
 void __attribute__((interrupt(),nomips16)) CoreTimerHandler(void)
 #endif

--- a/hardware/pic32/cores/pic32/wiring.h
+++ b/hardware/pic32/cores/pic32/wiring.h
@@ -179,17 +179,19 @@ unsigned int attachCoreTimerService(uint32_t (*)(uint32_t count));
 unsigned int detachCoreTimerService(uint32_t (*)(uint32_t count));
 unsigned int callCoreTimerServiceNow(uint32_t (* service)(uint32_t));
 
-#if defined(__PIC32MZXX__)
-    #define setIntVector(_vec, _func) NULL
-    #define getIntVector(_vec) NULL
-    #define clearIntVector(_vec) NULL
+// if you are going to use setIntVector, then specify the interrupt routine as:
+// void __USER_ISR UserInterrupt(void) {}
+#if defined(__PIC32MZ__)
+#define __USER_ISR __attribute__((nomips16, interrupt(), section(".user_interrupt")))
 #else
-    isrFunc setIntVector(int vec, isrFunc func);
-    isrFunc getIntVector(int vec);
-    isrFunc clearIntVector(int vec);
+#define __USER_ISR __attribute__((nomips16, interrupt()))
 #endif
-    void setIntPriority(int vec, int ipl, int spl);
-    void getIntPriority(int vec, int * pipl, int * pspl);
+
+isrFunc setIntVector(int vec, isrFunc func);
+isrFunc getIntVector(int vec);
+isrFunc clearIntVector(int vec);
+void setIntPriority(int vec, int ipl, int spl);
+void getIntPriority(int vec, int * pipl, int * pspl);
 
 
 /* ------------------------------------------------------------ */
@@ -390,6 +392,7 @@ extern const IMAGE_HEADER_INFO _image_header_info;      // this is the header in
 // programs some of its own data when writing the header to program flash.
 // The bootloader will add such things as the bootloader version and capabilities
 // vend ID, prod ID etc...
+extern const uint32_t _ebase_address;                           // a pointer to the ebase register value
 extern const uint32_t _IMAGE_PTR_TABLE;                         // a pointer to a table of 2 items, ebase and image header
 extern const uint32_t _IMAGE_HEADER_ADDR;                       // a pointer to the image header, the second item given in the table
 #define _IMAGE_EBASE_ADDR _IMAGE_PTR_TABLE                      // Really, the first item in the table is the ebase address.

--- a/hardware/pic32/libraries/DEWFcK/examples/WiFiScan/WiFiScan.pde
+++ b/hardware/pic32/libraries/DEWFcK/examples/WiFiScan/WiFiScan.pde
@@ -148,7 +148,7 @@ void loop()
                     Serial.print("SSID: ");
                     for(j=0; j<scanInfo.ssidLen; j++)
                     {
-                        Serial.print(scanInfo.ssid[j]);
+                        Serial.print((char) scanInfo.ssid[j]);
                     }
                     Serial.println();
 

--- a/hardware/pic32/libraries/DSPI/DSPI.cpp
+++ b/hardware/pic32/libraries/DSPI/DSPI.cpp
@@ -1379,7 +1379,7 @@ extern "C" {
 #if defined(_DSPI0_VECTOR)
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_DSPI0_VECTOR),interrupt(_DSPI0_IPL_ISR))) IntDspi0Handler(void)
+void __attribute__((nomips16,at_vector(_DSPI0_VECTOR),interrupt(_DSPI0_IPL_ISR))) IntDspi0Handler(void)
 #else
 void __attribute__((interrupt(), nomips16)) IntDspi0Handler(void)
 #endif
@@ -1409,7 +1409,7 @@ void __attribute__((interrupt(), nomips16)) IntDspi0Handler(void)
 #if defined(_DSPI1_VECTOR)
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_DSPI1_VECTOR),interrupt(_DSPI1_IPL_ISR))) IntDspi1Handler(void)
+void __attribute__((nomips16,at_vector(_DSPI1_VECTOR),interrupt(_DSPI1_IPL_ISR))) IntDspi1Handler(void)
 #else
 void __attribute__((interrupt(), nomips16)) IntDspi1Handler(void)
 #endif
@@ -1439,7 +1439,7 @@ void __attribute__((interrupt(), nomips16)) IntDspi1Handler(void)
 #if defined(_DSPI2_VECTOR)
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_DSPI2_VECTOR),interrupt(_DSPI2_IPL_ISR))) IntDspi2Handler(void)
+void __attribute__((nomips16,at_vector(_DSPI2_VECTOR),interrupt(_DSPI2_IPL_ISR))) IntDspi2Handler(void)
 #else
 void __attribute__((interrupt(), nomips16)) IntDspi2Handler(void)
 #endif
@@ -1469,7 +1469,7 @@ void __attribute__((interrupt(), nomips16)) IntDspi2Handler(void)
 #if defined(_DSPI3_VECTOR)
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_DSPI3_VECTOR),interrupt(_DSPI3_IPL_ISR))) IntDspi3Handler(void)
+void __attribute__((nomips16,at_vector(_DSPI3_VECTOR),interrupt(_DSPI3_IPL_ISR))) IntDspi3Handler(void)
 #else
 void __attribute__((interrupt(), nomips16)) IntDspi3Handler(void)
 #endif

--- a/hardware/pic32/libraries/HTTPServer/ProcessServer.cpp
+++ b/hardware/pic32/libraries/HTTPServer/ProcessServer.cpp
@@ -313,7 +313,7 @@ void ProcessServer(void)
                     Serial.print("SSID: ");
                     for(j=0; j<scanInfo.ssidLen; j++)
                     {
-                        Serial.print(scanInfo.ssid[j]);
+                        Serial.print((char) scanInfo.ssid[j]);
                     }
                     Serial.println();
 

--- a/hardware/pic32/libraries/MRF24G/utility/wf_eint_stub.c
+++ b/hardware/pic32/libraries/MRF24G/utility/wf_eint_stub.c
@@ -238,7 +238,11 @@ bool WF_isEintPending(void)
   Remarks:
     None
 *****************************************************************************/
+#if defined(__PIC32MZXX__)
+void __attribute((interrupt(WF_IPL_ISR), at_vector(WF_INT_VEC), nomips16)) _WFInterrupt(void)
+#else
 void __attribute((interrupt(WF_IPL_ISR), vector(WF_INT_VEC), nomips16)) _WFInterrupt(void)
+#endif
 {
     // clear EINT
     WIFI_IFSxCLR = WIFI_INT_MASK;        // clear the interrupt

--- a/hardware/pic32/libraries/Servo/utility/int.c
+++ b/hardware/pic32/libraries/Servo/utility/int.c
@@ -48,7 +48,7 @@
 //	more generic.
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_TIMER_3_VECTOR),interrupt(IPL4SRS))) T3_IntHandler(void)
+void __attribute__((nomips16,at_vector(_TIMER_3_VECTOR),interrupt(IPL4SRS))) T3_IntHandler(void)
 #else
 void __attribute__((interrupt(),nomips16)) T3_IntHandler (void)
 #endif
@@ -59,7 +59,7 @@ void __attribute__((interrupt(),nomips16)) T3_IntHandler (void)
 
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_TIMER_4_VECTOR),interrupt(IPL4SRS))) T4_IntHandler(void)
+void __attribute__((nomips16,at_vector(_TIMER_4_VECTOR),interrupt(IPL4SRS))) T4_IntHandler(void)
 #else
 void __attribute__((interrupt(),nomips16)) T4_IntHandler (void)
 #endif
@@ -69,7 +69,7 @@ void __attribute__((interrupt(),nomips16)) T4_IntHandler (void)
 }
 
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_TIMER_5_VECTOR),interrupt(IPL4SRS))) T5_IntHandler(void)
+void __attribute__((nomips16,at_vector(_TIMER_5_VECTOR),interrupt(IPL4SRS))) T5_IntHandler(void)
 #else
 void __attribute__((interrupt(),nomips16)) T5_IntHandler (void)
 #endif

--- a/hardware/pic32/libraries/Wire/DTWI.cpp
+++ b/hardware/pic32/libraries/Wire/DTWI.cpp
@@ -58,9 +58,6 @@
 #define read_count(dest) __asm__ __volatile__("mfc0 %0,$9" : "=r" (dest))
 #define CORETIMER_TICKS_PER_MICROSECOND		(F_CPU / 2 / 1000000UL)
 
-// this is used for MZ parts
-#define pISROffset  ((uint32_t *) &OFF000)
-
 /************************************************************************/
 /************************************************************************/
 /*                      CONSTRUCTORS                                    */
@@ -104,8 +101,8 @@ DTWI::DTWI(p32_i2c * ptwiC, uint8_t irqBusC, uint8_t vecC, uint8_t iplC, uint8_t
     // the MZ part works off of offset tables
     // We are given the BUS VEC, and we must fill in the 
     // the SLAVE and MASTER VECs as well
-    pISROffset[vec+1] = pISROffset[vec];
-    pISROffset[vec+2] = pISROffset[vec];
+    setIntVector(vec+1, getIntVector(vec));
+    setIntVector(vec+2, getIntVector(vec));
 
     // and set the priorities for the other 2 vectors.
     setIntPriority(vec+1, ipl, spl);
@@ -1441,7 +1438,7 @@ DTWI0::DTWI0() : DTWI(((p32_i2c *) _DTWI0_BASE), _DTWI0_BUS_IRQ, _DTWI0_VECTOR, 
 
 // the associated interrupt routine.
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_DTWI0_VECTOR),interrupt(_DTWI0_IPL_ISR))) IntDtwi0Handler(void)
+void __attribute__((nomips16,at_vector(_DTWI0_VECTOR),interrupt(_DTWI0_IPL_ISR))) IntDtwi0Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) IntDtwi0Handler(void)
 #endif
@@ -1466,7 +1463,7 @@ DTWI1::DTWI1() : DTWI(((p32_i2c *) _DTWI1_BASE), _DTWI1_BUS_IRQ, _DTWI1_VECTOR, 
 
 // the associated interrupt routine.
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_DTWI1_VECTOR),interrupt(_DTWI1_IPL_ISR))) IntDtwi1Handler(void)
+void __attribute__((nomips16,at_vector(_DTWI1_VECTOR),interrupt(_DTWI1_IPL_ISR))) IntDtwi1Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) IntDtwi1Handler(void)
 #endif
@@ -1491,7 +1488,7 @@ DTWI2::DTWI2() : DTWI(((p32_i2c *) _DTWI2_BASE), _DTWI2_BUS_IRQ, _DTWI2_VECTOR, 
 
 // the associated interrupt routine.
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_DTWI2_VECTOR),interrupt(_DTWI2_IPL_ISR))) IntDtwi2Handler(void)
+void __attribute__((nomips16,at_vector(_DTWI2_VECTOR),interrupt(_DTWI2_IPL_ISR))) IntDtwi2Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) IntDtwi2Handler(void)
 #endif
@@ -1516,7 +1513,7 @@ DTWI3::DTWI3() : DTWI(((p32_i2c *) _DTWI3_BASE), _DTWI3_BUS_IRQ, _DTWI3_VECTOR, 
 
 // the associated interrupt routine.
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_DTWI3_VECTOR),interrupt(_DTWI3_IPL_ISR))) IntDtwi3Handler(void)
+void __attribute__((nomips16,at_vector(_DTWI3_VECTOR),interrupt(_DTWI3_IPL_ISR))) IntDtwi3Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) IntDtwi3Handler(void)
 #endif
@@ -1541,7 +1538,7 @@ DTWI4::DTWI4() : DTWI(((p32_i2c *) _DTWI4_BASE), _DTWI4_BUS_IRQ, _DTWI4_VECTOR, 
 
 // the associated interrupt routine.
 #if defined(__PIC32MZXX__)
-void __attribute__((nomips16,vector(_DTWI4_VECTOR),interrupt(_DTWI4_IPL_ISR))) IntDtwi4Handler(void)
+void __attribute__((nomips16,at_vector(_DTWI4_VECTOR),interrupt(_DTWI4_IPL_ISR))) IntDtwi4Handler(void)
 #else
 void __attribute__((interrupt(),nomips16)) IntDtwi4Handler(void)
 #endif


### PR DESCRIPTION
This updates the interrupt handling to support setIntVector on MZ which enables attachInterrupts() on the MZ. Plus it does at_vectors for the interrupt routines so we don't execute through a jump instruction. Updated WiFiScan and HTTPServer SSID print statements to 1.5 Print()
