### PR TITLE
fix SPI speed for MZ

### DIFF
--- a/hardware/pic32/libraries/DSPI/DSPI.cpp
+++ b/hardware/pic32/libraries/DSPI/DSPI.cpp
@@ -337,7 +337,7 @@ DSPI::begin(uint8_t pinT) {
 
 	/* Set the default baud rate.
 	*/
-	brg = (uint16_t)((F_CPU / (2 * _DSPI_SPD_DEFAULT)) - 1);
+	brg = (uint16_t)((__PIC32_pbClk / (2 * _DSPI_SPD_DEFAULT)) - 1);
 	pspi->sxBrg.reg = brg;
 
 	/* Clear the receive overflow bit and receive overflow error flag
@@ -406,7 +406,7 @@ DSPI::setSpeed(uint32_t spd) {
 
 	/* Compute the baud rate divider for this frequency.
 	*/
-	brg = (uint16_t)((F_CPU / (2 * spd)) - 1);
+	brg = (uint16_t)((__PIC32_pbClk / (2 * spd)) - 1);
 
 	/* That the baud rate value is in the correct range.
 	*/


### PR DESCRIPTION
The MZ by default has a divide by 2 on the peripheral clock which effects the SPI BRG calculations differently than the MX which is a divide by 1 on the peripheral clock. Instead of basing the BRG calculations on FCPU, base it on the more appropriate peripheral clock speed. 
