### PR TITLE
Recapitalized CDCACM product to match bootloader

### DIFF
--- a/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.c
+++ b/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.c
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef CDCACM_PROD
-#define CDCACM_PROD "stk500v2"
+#define CDCACM_PROD "Stk500v2"
 #endif
 
 #ifndef CDCACM_SER


### PR DESCRIPTION
This should help address the issue of Fubarino boards wandering between COM ports when entering the bootloader.
