### PR TITLE
Added method to get current baud rate from USB serial

### DIFF
--- a/hardware/pic32/cores/pic32/HardwareSerial.cpp
+++ b/hardware/pic32/cores/pic32/HardwareSerial.cpp
@@ -663,6 +663,14 @@ void USBSerial::end()
 }
 
 //*******************************************************************************************
+extern "C" uint8_t *cdcacm_get_line_coding();
+unsigned long USBSerial::getBaudRate() {
+    uint8_t *line_coding = cdcacm_get_line_coding();
+    uint32_t br = line_coding[0] | (line_coding[1] << 8) | (line_coding[2] << 16) | (line_coding[3] << 24);
+    return br;
+}
+
+//*******************************************************************************************
 int USBSerial::available(void)
 {
 	return (RX_BUFFER_SIZE + _rx_buffer->head - _rx_buffer->tail) % RX_BUFFER_SIZE;

--- a/hardware/pic32/cores/pic32/HardwareSerial.h
+++ b/hardware/pic32/cores/pic32/HardwareSerial.h
@@ -154,6 +154,7 @@ class USBSerial : public Stream
 		virtual size_t	write(const char *str);
 		virtual size_t	write(const uint8_t *buffer, size_t size);
         operator        int();
+        virtual unsigned long getBaudRate();
 
 		using	Print::write; // pull in write(str) and write(buf, size) from Print
 };

--- a/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.c
+++ b/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.c
@@ -377,6 +377,10 @@ static uint8 line_coding[7] =
 	FILL_LINE_CODING(115200, 0, 0, 8) /* Default is 115200 BPS and 8N1 format. */
 };
 
+uint8_t *cdcacm_get_line_coding() {
+    return line_coding;
+}
+
 //************************************************************************
 // this function implements the CDCACM usb setup control transfer.
 //************************************************************************


### PR DESCRIPTION
You can now find the current baud rate as requested by the host in a USB serial interface.

    Serial.getBaudRate();

Returns the baud rate decoded from the line_coding data provided by USB CDC/ACM.