### PR TITLE
Added unsetSpeed() and unsetMode() functions

### DIFF
--- a/hardware/pic32/libraries/DSPI/DSPI.cpp
+++ b/hardware/pic32/libraries/DSPI/DSPI.cpp
@@ -435,9 +435,17 @@ DSPI::setSpeed(uint32_t spd) {
 	** controller before writing to the baud register
 	*/
 	pspi->sxCon.clr = (1 << _SPICON_ON);	// disable SPI
+    storedBrg = pspi->sxBrg.reg;
 	pspi->sxBrg.reg = brg;
 	pspi->sxCon.set = (1 << _SPICON_ON);	// enable SPI
 
+}
+
+/* Undo the last setSpeed() call to restore the previous baud rate */
+void DSPI::unsetSpeed() { 
+	pspi->sxCon.clr = (1 << _SPICON_ON);	// disable SPI
+	pspi->sxBrg.reg = storedBrg;
+	pspi->sxCon.set = (1 << _SPICON_ON);	// enable SPI
 }
 
 /* ------------------------------------------------------------ */
@@ -467,6 +475,7 @@ DSPI::setMode(uint16_t mod) {
 		return;
 	}
 
+    storedMode = pspi->sxCon.reg & ((1 << _SPICON_CKP)|(1 << _SPICON_CKE));
 	pspi->sxCon.clr = (1 << _SPICON_ON);
 	pspi->sxCon.clr =((1 << _SPICON_CKP)|(1 << _SPICON_CKE));	// force both mode bits to 0
 
@@ -474,6 +483,16 @@ DSPI::setMode(uint16_t mod) {
 	pspi->sxCon.set = (1 << _SPICON_ON);
 	
 }
+
+/* Undo the last setMode call */
+void DSPI::unsetMode() {
+	pspi->sxCon.clr = (1 << _SPICON_ON);
+	pspi->sxCon.clr =((1 << _SPICON_CKP)|(1 << _SPICON_CKE));	// force both mode bits to 0
+
+	pspi->sxCon.set = storedMode;
+	pspi->sxCon.set = (1 << _SPICON_ON);
+} 
+
 
 /* ------------------------------------------------------------ */
 /***	DSPI::setPinSelect

--- a/hardware/pic32/libraries/DSPI/DSPI.h
+++ b/hardware/pic32/libraries/DSPI/DSPI.h
@@ -109,6 +109,9 @@ private:
 	ppsFunctionType		ppsMOSI;		//PPS select for SPI MOSI
 #endif	
 
+    uint32_t            storedBrg;      // Previous baud rate before a setSpeed
+    uint32_t            storedMode;     // Previous mode before a setMode
+
 	void	doDspiInterrupt();
 
 protected:
@@ -138,7 +141,9 @@ void        begin(uint8_t miso, uint8_t mosi, uint8_t pin);
 #endif
 void		end();
 void		setSpeed(uint32_t spd);
+void        unsetSpeed();
 void		setMode(uint16_t  mod);
+void        unsetMode();
 void		setPinSelect(uint8_t pin);
 void		setTransferSize(uint8_t txsize);
 


### PR DESCRIPTION
For DSPI:

  * setSpeed() and setMode() now store the previous speed and mode
    which can be restored with unsetSpeed() and unsetMode() respectively.
    This allows you to use SPI devices on the same bus where different devices
    want to operate with different settings.