### PR TITLE
USB handshaking fix for issue #466:

### DIFF
--- a/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.h
+++ b/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.h
@@ -6,6 +6,9 @@
 #include <string.h>
 
 #define     USB_SERIAL_MIN_BUFFER_FREE      128
+// Number of milliseconds we will wait before giving up while trying to 
+// send data up to the PC.
+#define     USB_CDC_INACTIVE_TIMEOUT_MS     50
 
 extern boolean gCdcacm_active;
 extern boolean gConnected;


### PR DESCRIPTION
  We now refrain from sending any USB data up to the PC until one or more of the following happens:
    * The PC has sent some data to us or tries to read some data from us (i.e. an application has opened the part and sent some data out or is trying to read data in)
    * The PC has activated a hardware handshaking line (i.e. an application has opened the port - most apps do this)
  Once we are sending data to the PC, we will continue to do so until one of the following things happens:
    * The PC has deactivated the hardware handshaking line (i.e. the app has closed the port)
    * The PC has not asked for any data from us for 50ms (this indicates that there is no application consuming the data on the PC side, and the PC's buffer is full, and it doesn't want any more data)
I also bumped up the number of USB buffers to 16 (from 4), which seemed to help smooth things out somewhat

This fix has been tested with the Firmata Test application (which failed before this code was changed) on Mac and Windows, and Jacob tested this patch on some of his difficult USB cases (where things were failing previosly) and all of these tests were suecesful.