### PR TITLE
Fixed bug with Serial int() operator looking at wrong variable

### DIFF
--- a/hardware/pic32/cores/pic32/HardwareSerial.cpp
+++ b/hardware/pic32/cores/pic32/HardwareSerial.cpp
@@ -714,7 +714,7 @@ USBSerial::USBSerial(ring_buffer	*rx_buffer)
 }
 
 USBSerial::operator int() {
-    return gConnected ? 1 : 0;
+    return gCdcacm_active ? 1 : 0;
 }
 
 #ifdef _DEBUG_USB_VIA_SERIAL0_

--- a/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.c
+++ b/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.c
@@ -191,8 +191,6 @@ static int			gRX_length[NRX];
 static volatile byte			gRX_in;
 static volatile byte			gRX_out;
 
-boolean      gConnected = false;
-
 void setStrings(char *man, char *prod, char *ser) {
     int i;
     int pos = 0;

--- a/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.h
+++ b/hardware/pic32/cores/pic32/HardwareSerial_cdcacm.h
@@ -11,7 +11,6 @@
 #define     USB_CDC_INACTIVE_TIMEOUT_MS     50
 
 extern boolean gCdcacm_active;
-extern boolean gConnected;
 
 typedef void (*cdcacm_reset_cbfn)(void);
 typedef boolean (*cdcacm_storedata_cbfn)(const byte *buffer, int length);


### PR DESCRIPTION
With the attempted fix to the CDCACM connection problem a duplicate variable (gCdcacm_active) that performs the exact same function as an existing variable (gConnected) was created. The existing variable was partially removed from some places but not from others.  This meant that the USBSerial's int() operator no longer reported the correct connected status.

This patch reduces the number of variables performing the function back down to one.