### PR TITLE
Fixed compilation redefinition warnings

### DIFF
--- a/hardware/pic32/cores/pic32/p32_defs.h
+++ b/hardware/pic32/cores/pic32/p32_defs.h
@@ -506,13 +506,17 @@ typedef struct {
 #define _BN_OCCON_OCTSEL	3
 #define	_BN_OCCON_OCM		0
 
+#ifndef OCCON_ON
 #define OCCON_ON			(1 << _BN_OCCON_ON)
+#endif
 #define OCCON_OFF			(0)
 #define	OCCON_IDLE_STOP		(1 << _BN_OCCON_SIDL)
 #define	OCCON_IDLE_RUN		(0)
 #define OCCON_MODE32		(1 << _BN_OCCON_OC32)
 #define OCCON_MODE16		(0)
+#ifndef OCCON_OCFLT
 #define	OCCON_OCFLT			(1 << _BN_OCCON_OCFLT)
+#endif
 #define	OCCON_SRC_TIMER3	(1 << _BN_OCCON_OCTSEL)
 #define	OCCON_SRC_TIMER2	(0)
 


### PR DESCRIPTION
Some of our symbols for the OC module are already defined by the current compiler (not always been the case).  This small change just stops our core from redefining them again, thus suppressing some annoying warnings when you have warnings turned on.