### PR TITLE
Fixed incorrect file path separator and bad capitalization

### DIFF
--- a/hardware/pic32/libraries/IM8720PHY/IM8720Adaptor.c
+++ b/hardware/pic32/libraries/IM8720PHY/IM8720Adaptor.c
@@ -49,7 +49,7 @@
 /*	8/9/2013(KeithV): Created                                           */
 /*                                                                      */
 /************************************************************************/
-#include "..\DEIPck\utility\deIP.h"
+#include "../DEIPcK/utility/deIP.h"
 #include "IM8720Adaptor.h"
 
 #define FOREVER             (0xFFFFFFFF)


### PR DESCRIPTION
To maintain cross-platform compatibility two things must be carefully observed with `#include` statements:

1. The path separator must be a forward slash (`/`) not a back slash (`\`) since the latter is only valid on Windows.
2. The capitalization of all files must exactly match the filenames on disk since not all filesystems are case-insensitive.  Incorrect capitalization can result in "file not found" errors.