### PR TITLE
Fix for issue #532: SD Library compile error on MX1/MX2

### DIFF
--- a/hardware/pic32/cores/pic32/cpudefs.h
+++ b/hardware/pic32/cores/pic32/cpudefs.h
@@ -37,17 +37,18 @@
 
 //************************************************************************
 //*    Microchip pic32 chip names
-#if defined(__PIC32MX__)
+#if defined(__PIC32MX__) || defined(__PIC32MZ__)
 
     #define    E2END        0x0fff    //*    4 k of simulated EEPROM
     
     //************************************************************************
-    //*    100 series
+    //*    MX 100 series
 
     #if defined(__32MX110F016B__)
         #define _CPU_NAME_      "32MX110F016B"
         #define FLASHEND        (((16 - 4) * 1024L) - 1)
         #define RAMEND          ((4 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX1XX__
 
@@ -55,6 +56,7 @@
         #define _CPU_NAME_      "32MX110F016C"
         #define FLASHEND        (((16 - 4) * 1024L) - 1)
         #define RAMEND          ((4 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX1XX__
 
@@ -62,6 +64,7 @@
         #define _CPU_NAME_      "32MX110F016D"
         #define FLASHEND        (((16 - 4) * 1024L) - 1)
         #define RAMEND          ((4 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX1XX__
 
@@ -69,6 +72,7 @@
         #define _CPU_NAME_      "32MX120F032B"
         #define FLASHEND        (((32 - 4) * 1024L) - 1)
         #define RAMEND          ((8 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX1XX__
 
@@ -76,6 +80,7 @@
         #define _CPU_NAME_      "32MX120F032C"
         #define FLASHEND        (((32 - 4) * 1024L) - 1)
         #define RAMEND          ((8 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX1XX__
 
@@ -83,6 +88,7 @@
         #define _CPU_NAME_      "32MX120F032D"
         #define FLASHEND        (((32 - 4) * 1024L) - 1)
         #define RAMEND          ((8 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX1XX__
 
@@ -90,6 +96,7 @@
         #define _CPU_NAME_      "32MX130F064B"
         #define FLASHEND        (((64 - 4) * 1024L) - 1)
         #define RAMEND          ((16 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX1XX__
 
@@ -97,6 +104,7 @@
         #define _CPU_NAME_      "32MX130F064C"
         #define FLASHEND        (((64 - 4) * 1024L) - 1)
         #define RAMEND          ((16 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX1XX__
 
@@ -104,6 +112,7 @@
         #define _CPU_NAME_      "32MX130F064D"
         #define FLASHEND        (((64 - 4) * 1024L) - 1)
         #define RAMEND          ((16 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX1XX__
 
@@ -111,6 +120,7 @@
         #define _CPU_NAME_      "32MX150F128B"
         #define FLASHEND        (((128 - 4) * 1024L) - 1)
         #define RAMEND          ((32 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX1XX__
 
@@ -118,6 +128,7 @@
         #define _CPU_NAME_      "32MX150F128C"
         #define FLASHEND        (((128 - 4) * 1024L) - 1)
         #define RAMEND          ((32 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX1XX__
 
@@ -125,16 +136,18 @@
         #define _CPU_NAME_      "32MX150F128D"
         #define FLASHEND        (((128 - 4) * 1024L) - 1)
         #define RAMEND          ((32 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX1XX__
 
     //************************************************************************
-    //*    200 series
+    //*   MX 200 series
 
     #elif defined(__32MX210F016B__)
         #define _CPU_NAME_      "32MX210F016B"
         #define FLASHEND        (((16 - 4) * 1024L) - 1)
         #define RAMEND          ((4 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX2XX__
 
@@ -142,6 +155,7 @@
         #define _CPU_NAME_      "32MX210F016C"
         #define FLASHEND        (((16 - 4) * 1024L) - 1)
         #define RAMEND          ((4 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX2XX__
 
@@ -149,6 +163,7 @@
         #define _CPU_NAME_      "32MX210F016D"
         #define FLASHEND        (((16 - 4) * 1024L) - 1)
         #define RAMEND          ((4 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX2XX__
 
@@ -156,6 +171,7 @@
         #define _CPU_NAME_      "32MX220F032B"
         #define FLASHEND        (((32 - 4) * 1024L) - 1)
         #define RAMEND          ((8 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX2XX__
 
@@ -163,6 +179,7 @@
         #define _CPU_NAME_      "32MX220F032C"
         #define FLASHEND        (((32 - 4) * 1024L) - 1)
         #define RAMEND          ((8 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX2XX__
 
@@ -170,6 +187,7 @@
         #define _CPU_NAME_      "32MX220F032D"
         #define FLASHEND        (((32 - 4) * 1024L) - 1)
         #define RAMEND          ((8 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX2XX__
 
@@ -177,6 +195,7 @@
         #define _CPU_NAME_      "32MX230F064B"
         #define FLASHEND        (((64 - 4) * 1024L) - 1)
         #define RAMEND          ((16 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX2XX__
 
@@ -184,6 +203,7 @@
         #define _CPU_NAME_      "32MX230F064C"
         #define FLASHEND        (((64 - 4) * 1024L) - 1)
         #define RAMEND          ((16 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX2XX__
 
@@ -191,6 +211,7 @@
         #define _CPU_NAME_      "32MX230F064D"
         #define FLASHEND        (((64 - 4) * 1024L) - 1)
         #define RAMEND          ((16 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX2XX__
 
@@ -198,6 +219,7 @@
         #define _CPU_NAME_      "32MX250F128B"
         #define FLASHEND        (((128 - 4) * 1024L) - 1)
         #define RAMEND          ((32 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX2XX__
 
@@ -205,6 +227,7 @@
         #define _CPU_NAME_      "32MX250F128C"
         #define FLASHEND        (((128 - 4) * 1024L) - 1)
         #define RAMEND          ((32 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX2XX__
 
@@ -212,11 +235,12 @@
         #define _CPU_NAME_      "32MX250F128D"
         #define FLASHEND        (((128 - 4) * 1024L) - 1)
         #define RAMEND          ((32 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX2XX__
 
     //************************************************************************
-    //*    300 series
+    //*  MX  300 series
 
     #elif defined(__32MX320F032H__)
         #define _CPU_NAME_      "32MX320F032H"
@@ -289,7 +313,7 @@
         #define __PIC32MX3XX__
 
     //************************************************************************
-    //*    400 series
+    //*  MX  400 series
 
     #elif defined(__32MX420F032H__)
         #define _CPU_NAME_      "32MX420F032H"
@@ -357,7 +381,7 @@
         #define __PIC32MX47XL__
 
     //************************************************************************
-    //*    500 series
+    //*  MX  500 series
 
     #elif defined(__32MX534F064H__)
         #define _CPU_NAME_      "32MX534F064H"
@@ -430,7 +454,7 @@
         #define __PIC32MX5XX__
 
     //************************************************************************
-    //*    600 series
+    //*  MX  600 series
 
     #elif defined(__32MX664F064H__)
         #define _CPU_NAME_      "32MX664F064H"
@@ -503,7 +527,7 @@
         #define __PIC32MX6XX__
 
     //************************************************************************
-    //*    700 series
+    //*  MX  700 series
 
     #elif defined(__32MX764F128H__)
         #define _CPU_NAME_      "32MX764F128H"
@@ -561,18 +585,14 @@
         #define __PIC32_PINS__  100
         #define __PIC32MX7XX__
 
-
     //************************************************************************
-    #else
-        #error CPU type is unknown, cpudefs.h needs to have additions
-    #endif
-
-#elif defined(__PIC32MZ__)
-
-    #if defined(__32MZ1024ECG064__)
+    //*  MZ  EC series
+		
+    #elif defined(__32MZ1024ECG064__)
         #define _CPU_NAME_      "32MZ1024ECG064"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -580,6 +600,7 @@
         #define _CPU_NAME_      "32MZ1024ECH064"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -587,6 +608,7 @@
         #define _CPU_NAME_      "32MZ1024ECM064"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -594,6 +616,7 @@
         #define _CPU_NAME_      "32MZ2048ECG064"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -601,6 +624,7 @@
         #define _CPU_NAME_      "32MZ2048ECH064"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -608,6 +632,7 @@
         #define _CPU_NAME_      "32MZ2048ECM064"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -615,6 +640,7 @@
         #define _CPU_NAME_      "32MZ1024ECG100"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
  
@@ -622,6 +648,7 @@
         #define _CPU_NAME_      "32MZ1024ECH100"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -629,6 +656,7 @@
         #define _CPU_NAME_      "32MZ1024ECM100"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
  
@@ -636,6 +664,7 @@
         #define _CPU_NAME_      "32MZ2048ECG100"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -643,6 +672,7 @@
         #define _CPU_NAME_      "32MZ2048ECH100"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -650,6 +680,7 @@
         #define _CPU_NAME_      "32MZ2048ECM100"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -657,6 +688,7 @@
         #define _CPU_NAME_      "32MZ1024ECG124"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -664,6 +696,7 @@
         #define _CPU_NAME_      "32MZ1024ECH124"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -671,6 +704,7 @@
         #define _CPU_NAME_      "32MZ1024ECM124"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -678,6 +712,7 @@
         #define _CPU_NAME_      "32MZ2048ECG124"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -685,6 +720,7 @@
         #define _CPU_NAME_      "32MZ2048ECH124"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -692,6 +728,7 @@
         #define _CPU_NAME_      "32MZ2048EC124"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -699,6 +736,7 @@
         #define _CPU_NAME_      "32MZ1024ECG144"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
  
@@ -706,6 +744,7 @@
         #define _CPU_NAME_      "32MZ1024ECH144"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
@@ -713,6 +752,7 @@
         #define _CPU_NAME_      "32MZ1024ECM144"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
  
@@ -720,6 +760,7 @@
         #define _CPU_NAME_      "32MZ2048ECG144"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
@@ -727,6 +768,7 @@
         #define _CPU_NAME_      "32MZ2048ECH144"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
@@ -734,6 +776,7 @@
         #define _CPU_NAME_      "32MZ2048ECM144"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
  
@@ -741,6 +784,7 @@
         #define _CPU_NAME_      "32MZ0512ECE064"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
  
@@ -748,6 +792,7 @@
         #define _CPU_NAME_      "32MZ0512ECF064"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -755,6 +800,7 @@
         #define _CPU_NAME_      "32MZ0512ECK064"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
  
@@ -762,6 +808,7 @@
         #define _CPU_NAME_      "32MZ1024ECE064"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -769,6 +816,7 @@
         #define _CPU_NAME_      "32MZ1024ECF064"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -776,6 +824,7 @@
         #define _CPU_NAME_      "32MZ1024ECK064"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
  
@@ -783,6 +832,7 @@
         #define _CPU_NAME_      "32MZ0512ECE100"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -790,6 +840,7 @@
         #define _CPU_NAME_      "32MZ0512ECF100"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -797,6 +848,7 @@
         #define _CPU_NAME_      "32MZ0512ECK100"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -804,6 +856,7 @@
         #define _CPU_NAME_      "32MZ1024ECE100"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -811,6 +864,7 @@
         #define _CPU_NAME_      "32MZ1024ECF100"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -818,6 +872,7 @@
         #define _CPU_NAME_      "32MZ1024ECK100"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
  
@@ -825,6 +880,7 @@
         #define _CPU_NAME_      "32MZ0512ECE124"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -832,6 +888,7 @@
         #define _CPU_NAME_      "32MZ0512ECF124"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
  
@@ -839,6 +896,7 @@
         #define _CPU_NAME_      "32MZ0512ECK124"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
  
@@ -846,6 +904,7 @@
         #define _CPU_NAME_      "32MZ1024ECE124"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -853,6 +912,7 @@
         #define _CPU_NAME_      "32MZ1024ECF124"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -860,6 +920,7 @@
         #define _CPU_NAME_      "32MZ1024ECK124"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -867,13 +928,15 @@
         #define _CPU_NAME_      "32MZ0512ECE144"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
-     #elif defined(__32MZ0512ECF144__)
+    #elif defined(__32MZ0512ECF144__)
         #define _CPU_NAME_      "32MZ0512ECF144"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
  
@@ -881,6 +944,7 @@
         #define _CPU_NAME_      "32MZ0512ECK144"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
@@ -888,6 +952,7 @@
         #define _CPU_NAME_      "32MZ1024ECE144"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
@@ -895,6 +960,7 @@
         #define _CPU_NAME_      "32MZ1024ECF144"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
@@ -902,13 +968,18 @@
         #define _CPU_NAME_      "32MZ1024ECK144"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
+
+	//************************************************************************
+    //*   MZ   EF series
 
     #elif defined(__32MZ2048EFG064__)
         #define _CPU_NAME_      "32MZ2048EFG064"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -917,6 +988,7 @@
         #define _CPU_NAME_      "32MZ2048EFG100"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -925,6 +997,7 @@
         #define _CPU_NAME_      "32MZ2048EFG124"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -933,6 +1006,7 @@
         #define _CPU_NAME_      "32MZ2048EFG144"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -941,6 +1015,7 @@
         #define _CPU_NAME_      "32MZ2048EFH064"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -949,6 +1024,7 @@
         #define _CPU_NAME_      "32MZ2048EFH100"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -957,6 +1033,7 @@
         #define _CPU_NAME_      "32MZ2048EFH124"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -965,6 +1042,7 @@
         #define _CPU_NAME_      "32MZ2048EFH144"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -973,6 +1051,7 @@
         #define _CPU_NAME_      "32MZ2048EFM064"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -981,6 +1060,7 @@
         #define _CPU_NAME_      "32MZ2048EFM100"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -989,6 +1069,7 @@
         #define _CPU_NAME_      "32MZ2048EFM124"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -997,6 +1078,7 @@
         #define _CPU_NAME_      "32MZ2048EFM144"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
+		#define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -1004,14 +1086,14 @@
     #else
         #error CPU type is unknown, cpudefs.h needs to have additions
     #endif
+#endif //defined(__PIC32MX__) || defined(__PIC32MZ__)
 
-// do we have EF or EC ADCs
-#ifndef __PIC32MZEFADC__
-#define __PIC32MZECADC__
-#endif
-
-#else
-    #error unknown cpu architecture
+// Set up MZ ADC type	
+#if defined(__PIC32MZ__)
+	// do we have EF or EC ADCs
+	#ifndef __PIC32MZEFADC__
+		#define __PIC32MZECADC__
+	#endif
 #endif
 
 //************************************************************************

--- a/hardware/pic32/cores/pic32/wiring_digital.c
+++ b/hardware/pic32/cores/pic32/wiring_digital.c
@@ -50,7 +50,7 @@ uint32_t				bit;
 uint8_t					port;
 volatile p32_ioport *	iop;
 uint8_t		            timer;
-#if !defined(__PIC32MX1XX__) && !defined(__PIC32MX2XX__) && !defined(__PIC32MZXX__) && !defined(__PIC32MX47X__)
+#if !defined(__PIC32_PPS__)
 uint32_t                cn;
 #endif
 
@@ -84,7 +84,7 @@ int	_board_pinMode(uint8_t pin, uint8_t mode)
 	//* Obtain bit mask for the specific bit for this pin.
 	bit = digitalPinToBitMask(pin);
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 	volatile uint32_t *	pps;
 
 	// The MX1xx/MX2xx support peripheral pin select (PPS). It is necessary
@@ -115,7 +115,7 @@ int	_board_pinMode(uint8_t pin, uint8_t mode)
 		AD1PCFGSET = bit;
 
 	}
-#endif	// defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MX47X__)
+#endif	// defined(__PIC32_PPS__)
 
 	// Set the pin to the requested mode.
     switch (mode) {
@@ -123,7 +123,7 @@ int	_board_pinMode(uint8_t pin, uint8_t mode)
         case INPUT_PULLUP:
         case INPUT_PULLDOWN:
         case INPUT_PULLUPDOWN:
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
             if (mode == INPUT_PULLUP) {
                 iop->cnpu.set = bit;
                 iop->cnpd.clr = bit;
@@ -173,7 +173,7 @@ int	_board_pinMode(uint8_t pin, uint8_t mode)
             // The behavior inherited from Arduino is that if INPUT wasn't
             // specified you get OUTPUT. That behavior is preserved rather
             // than error checking the input value.
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
             iop->cnpu.clr = bit;
             iop->cnpd.clr = bit;
 #else
@@ -261,7 +261,7 @@ volatile p32_ioport *	iop;
 uint8_t					port;
 uint16_t				bit;
 uint8_t					timer;
-#if !defined(__PIC32MX1XX__) && !defined(__PIC32MX2XX__) && !defined(__PIC32MZXX__) && !defined(__PIC32MX47X__)
+#if !defined(__PIC32_PPS__)
 uint32_t                cn;
 #endif
 
@@ -300,7 +300,7 @@ int	_board_digitalWrite(uint8_t pin, uint8_t val);
     //* resistor.  Only works for pins that have an associated
     //* change notification pin.
     if (iop->tris.reg & bit) {
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
         if (val == LOW) {
             iop->cnpu.clr = bit;
             iop->cnpd.clr = bit;
@@ -380,8 +380,8 @@ uint8_t	tmp;
 	//* Obtain bit mask for the specific bit for this pin.
 	bit = digitalPinToBitMask(pin);
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
-	// The MX1xx-MX2xx devices have an ANSELx register associated with
+#if defined(__PIC32_PPS__)
+	// The devices with PPS have an ANSELx register associated with
 	// each io port that is used to control analog/digital mode of the
 	// analog input capable pins.
 	// Clear the bit in the ANSELx register to ensure that the pin is in
@@ -398,9 +398,8 @@ uint8_t	tmp;
 		//	digital input using AD1PCFG.
 
 		AD1PCFGSET = bit;
-
 	}
-#endif	// defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MX47X__)
+#endif	// defined(__PIC32_PPS__)
 
 	//* Get the pin state.
 	if ((iop->port.reg & bit) != 0) 

--- a/hardware/pic32/libraries/SD/SD.h
+++ b/hardware/pic32/libraries/SD/SD.h
@@ -66,8 +66,10 @@ private:
   SdFile getParentDir(const char *filepath, int *indx);
 public:
   // This needs to be called to set up the connection to the SD card
-  // before other methods are used.
-  boolean begin(uint8_t csPin = SD_CHIP_SELECT_PIN);
+  // before other methods are used. SS is defined in the Board_Defs.h variant file, and is
+  // normally the same as the real hardware SPI SS pin. We use it here even though we bit-bang
+  // everything because that way there's a way to know which pin is a good SS pin for each board.
+  boolean begin(uint8_t csPin = SS);
   
   // Open the specified file/directory with the supplied mode (e.g. read or
   // write, etc). Returns a File object for interacting with the file.

--- a/hardware/pic32/libraries/SD/utility/Sd2Card.h
+++ b/hardware/pic32/libraries/SD/utility/Sd2Card.h
@@ -25,6 +25,7 @@
  */
 #include "Sd2PinMap.h"
 #include "SdInfo.h"
+#include <Board_Defs.h>
 //#include <plib.h>
 
 /** Set SCK to max rate of F_CPU/2. See Sd2Card::setSckRate(). */
@@ -33,54 +34,7 @@ uint8_t const SPI_FULL_SPEED = 0;
 uint8_t const SPI_HALF_SPEED = 1;
 /** Set SCK rate to F_CPU/8. Sd2Card::setSckRate(). */
 uint8_t const SPI_QUARTER_SPEED = 2;
-/**
- * Define MEGA_SOFT_SPI non-zero to use software SPI on Mega Arduinos.
- * Pins used are SS 10, MOSI 11, MISO 12, and SCK 13.
- *
- * MEGA_SOFT_SPI allows an unmodified Adafruit GPS Shield to be used
- * on Mega Arduinos.  Software SPI works well with GPS Shield V1.1
- * but many SD cards will fail with GPS Shield V1.0.
- */
-#define MEGA_SOFT_SPI 1
-//------------------------------------------------------------------------------
-#if MEGA_SOFT_SPI
-#define SOFTWARE_SPI
-#endif  // MEGA_SOFT_SPI
-//------------------------------------------------------------------------------
-// SPI pin definitions
-//
-#ifndef SOFTWARE_SPI
-// hardware pin defs
-/**
- * SD Chip Select pin
- *
- * Warning if this pin is redefined the hardware SS will pin will be enabled
- * as an output by init().  An avr processor will not function as an SPI
- * master unless SS is set to output mode.
- */
-/** The default chip select pin for the SD card is SS. */
-//uint8_t const  SD_CHIP_SELECT_PIN = SS_PIN;
-//// The following three pins must not be redefined for hardware SPI.
-///** SPI Master Out Slave In pin */
-//uint8_t const  SPI_MOSI_PIN = MOSI_PIN;
-///** SPI Master In Slave Out pin */
-//uint8_t const  SPI_MISO_PIN = MISO_PIN;
-///** SPI Clock pin */
-//uint8_t const  SPI_SCK_PIN = SCK_PIN;
-/** optimize loops for hardware SPI */
-#define OPTIMIZE_HARDWARE_SPI
 
-#else  // SOFTWARE_SPI
-// define software SPI pins so Mega can use unmodified GPS Shield
-/** SPI chip select pin */
-uint8_t const SD_CHIP_SELECT_PIN = 10;
-/** SPI Master Out Slave In pin */
-uint8_t const SPI_MOSI_PIN = 11;
-/** SPI Master In Slave Out pin */
-uint8_t const SPI_MISO_PIN = 12;
-/** SPI Clock pin */
-uint8_t const SPI_SCK_PIN = 13;
-#endif  // SOFTWARE_SPI
 //------------------------------------------------------------------------------
 /** Protect block zero from write if nonzero */
 #define SD_PROTECT_BLOCK_ZERO 1
@@ -169,7 +123,7 @@ class Sd2Card {
    * select pin.  See sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin).
    */
   uint8_t init(void) {
-    return init(SPI_FULL_SPEED, SD_CHIP_SELECT_PIN);
+    return init(SPI_FULL_SPEED, SS);
   }
   /**
    * Initialize an SD flash memory card with the selected SPI clock rate
@@ -177,7 +131,7 @@ class Sd2Card {
    * See sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin).
    */
   uint8_t init(uint8_t sckRateID) {
-    return init(sckRateID, SD_CHIP_SELECT_PIN);
+    return init(sckRateID, SS);
   }
   uint8_t init(uint8_t sckRateID, uint8_t chipSelectPin);
   void partialBlockRead(uint8_t value);

--- a/hardware/pic32/libraries/SD/utility/Sd2PinMap.h
+++ b/hardware/pic32/libraries/SD/utility/Sd2PinMap.h
@@ -65,11 +65,12 @@
 #define PORTSetPinsDigitalInX(PORTx, BITS) TRIS##PORTx##SET = BITS
 #define PORTSetPinsDigitalIn(PORTx, BITS) PORTSetPinsDigitalInX(PORTx, BITS)
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32_PPS__)
     #define PORTSetAsDigitalPinX(PORTx, BITS) ANSEL##PORTx##CLR = BITS
     #define PORTSetAsDigitalPin(PORTx, BITS) PORTSetAsDigitalPinX(PORTx, BITS)
 #endif
 
+/* These are the bit-bang SPI port I/O pins for UNO32, MAX32, and UC32 */
 #if defined(_BOARD_MEGA_) || defined(_BOARD_UNO_) || defined(_BOARD_UC32_)
 
 	//Pin 11
@@ -85,48 +86,49 @@
 	#define bnSCK				BIT_6
 
 #elif defined(_BOARD_WF32_)
-        //uc Pin 52
-        #define prtSDO				IOPORT_G
-        #define	bnSDO				BIT_13
 
-        //uc Pin 49
-        #define prtSDI				IOPORT_G
-        #define bnSDI				BIT_15
+    //uc Pin 52
+    #define prtSDO				IOPORT_G
+    #define	bnSDO				BIT_13
 
-        //uc Pin 50
-        #define prtSCK				IOPORT_G
-        #define bnSCK				BIT_14
+    //uc Pin 49
+    #define prtSDI				IOPORT_G
+    #define bnSDI				BIT_15
+
+    //uc Pin 50
+    #define prtSCK				IOPORT_G
+    #define bnSCK				BIT_14
 
 #elif defined(_BOARD_WIFIRE_)
-        //uc Pin 54
-        #define prtSDO				IOPORT_C
-        #define	bnSDO				BIT_4
-        #define SD_SDO_PPS()                    RPC4R   = 0b0000    // Bit Banging SPI, set as GPIO
 
-        //uc Pin 53
-        #define prtSDI				IOPORT_B
-        #define bnSDI				BIT_10
-        #define SD_SDI_PPS()                                        // Bit Banging SPI, leave as nothing
+    //uc Pin 54
+    #define prtSDO				IOPORT_C
+    #define	bnSDO				BIT_4
+    #define SD_SDO_PPS()                    RPC4R   = 0b0000    // Bit Banging SPI, set as GPIO
 
-        //uc Pin 51
-        #define prtSCK				IOPORT_B
-        #define bnSCK				BIT_14
-        #define SD_SCK_PPS()                    RPB14R  = 0b0000    // Bit Banging SPI, set as GPIO
+    //uc Pin 53
+    #define prtSDI				IOPORT_B
+    #define bnSDI				BIT_10
+    #define SD_SDI_PPS()                                        // Bit Banging SPI, leave as nothing
 
+    //uc Pin 51
+    #define prtSCK				IOPORT_B
+    #define bnSCK				BIT_14
+    #define SD_SCK_PPS()                    RPB14R  = 0b0000    // Bit Banging SPI, set as GPIO
 
 #elif defined(_BOARD_PONTECH_QUICK240_USB_)
 
-        //uc Pin 72
-        #define prtSDO				IOPORT_D
-        #define	bnSDO				BIT_0
+    //uc Pin 72
+    #define prtSDO				IOPORT_D
+    #define	bnSDO				BIT_0
 
-        //uc Pin 9
-        #define prtSDI				IOPORT_C
-        #define bnSDI				BIT_4
+    //uc Pin 9
+    #define prtSDI				IOPORT_C
+    #define bnSDI				BIT_4
 
-        //uc Pin 70
-        #define prtSCK				IOPORT_D
-        #define bnSCK				BIT_10
+    //uc Pin 70
+    #define prtSCK				IOPORT_D
+    #define bnSCK				BIT_10
 
 #elif defined(_BOARD_CEREBOT_MX3CK_)
 
@@ -161,21 +163,114 @@
 	#define	prtSCK				IOPORT_F
 	#define	bnSCK				BIT_13
 
-#elif defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#elif defined(_BOARD_FUBARINO_SD_)
+
+	#define prtSDO				IOPORT_G
+	#define	bnSDO				BIT_8
+
+	#define prtSDI				IOPORT_G
+	#define bnSDI				BIT_7
+
+	#define prtSCK				IOPORT_G
+	#define bnSCK				BIT_6
+
+#elif defined(_BOARD_FUBARINO_MINI_)
+
+    // Digital pin 29
+	#define prtSDO				IOPORT_C
+	#define	bnSDO				BIT_8
+	#define SD_SDO_PPS()        RPC8R   = 0b0000    // Bit Banging SPI, set as GPIO
+
+    // Digital pin 27
+	#define prtSDI				IOPORT_C
+	#define bnSDI				BIT_6
+	#define SD_SDI_PPS()                            // Bit Banging SPI, leave as nothing
+
+    // Digital pin 4
+	#define prtSCK				IOPORT_B
+	#define bnSCK				BIT_15
+	#define SD_SCK_PPS()        RPB15R  = 0b0000    // Bit Banging SPI, set as GPIO
+	
+#elif defined(_BOARD_CHIPKIT_PI_)
+
+	// Digital pin 11
+	#define prtSDO				IOPORT_A
+	#define	bnSDO				BIT_1
+	#define SD_SDO_PPS()        RPA1R   = 0b0000    // Bit Banging SPI, set as GPIO
+
+	// Digital pin 12
+	#define prtSDI				IOPORT_B
+	#define bnSDI				BIT_8
+	#define SD_SDI_PPS()                            // Bit Banging SPI, leave as nothing
+
+	// Digital pin 13
+	#define prtSCK				IOPORT_B
+	#define bnSCK				BIT_14
+	#define SD_SCK_PPS()        RPB14R  = 0b0000    // Bit Banging SPI, set as GPIO
+	
+#elif defined(_BOARD_DP32_)
+
+	// Digital pin 18
+	#define prtSDO				IOPORT_A
+	#define	bnSDO				BIT_4
+	#define SD_SDO_PPS()        RPA4R   = 0b0000    // Bit Banging SPI, set as GPIO
+
+	// Digital pin 10
+	#define prtSDI				IOPORT_A
+	#define bnSDI				BIT_1
+	#define SD_SDI_PPS()                            // Bit Banging SPI, leave as nothing
+
+	// Digital pin 7
+	#define prtSCK				IOPORT_B
+	#define bnSCK				BIT_14
+	#define SD_SCK_PPS()        RPB14R  = 0b0000    // Bit Banging SPI, set as GPIO
+
+#elif defined(_BOARD_CMOD_)
+
+	// Digital pin 25
+	#define prtSDO				IOPORT_C
+	#define	bnSDO				BIT_1
+	#define SD_SDO_PPS()        RPC1R   = 0b0000    // Bit Banging SPI, set as GPIO
+
+	// Digital pin 35
+	#define prtSDI				IOPORT_B
+	#define bnSDI				BIT_5
+	#define SD_SDI_PPS()                            // Bit Banging SPI, leave as nothing
+
+	// Digital pin 16
+	#define prtSCK				IOPORT_B
+	#define bnSCK				BIT_14
+	#define SD_SCK_PPS()        RPB14R  = 0b0000    // Bit Banging SPI, set as GPIO
+
+#elif defined(_BOARD_FUBARINO_SDZ_)
+
+	// Digital pin 25
+	#define prtSDO				IOPORT_G
+	#define	bnSDO				BIT_8
+	#define SD_SDO_PPS()        RPG8R   = 0b0000    // Bit Banging SPI, set as GPIO
+
+	// Digital pin 35
+	#define prtSDI				IOPORT_G
+	#define bnSDI				BIT_7
+	#define SD_SDI_PPS()                            // Bit Banging SPI, leave as nothing
+
+	// Digital pin 16
+	#define prtSCK				IOPORT_G
+	#define bnSCK				BIT_6
+	#define SD_SCK_PPS()        RPG6R  = 0b0000    // Bit Banging SPI, set as GPIO
+
+#elif defined(__PIC32_PPS__)
     #error Boards with PPS must be specifically defined
 
 #else
 //*	Dec 14, 2011	<MLS>	Issue #160 this is the same, but we have to have a default, this still needs work
 
-	//Pin 11
 	#define prtSDO				IOPORT_G
 	#define	bnSDO				BIT_8
 
-	//Pin 12
 	#define prtSDI				IOPORT_G
 	#define bnSDI				BIT_7
 
-	//Pin 13
 	#define prtSCK				IOPORT_G
 	#define bnSCK				BIT_6
 

--- a/hardware/pic32/variants/Fubarino_Mini/Board_Defs.h
+++ b/hardware/pic32/variants/Fubarino_Mini/Board_Defs.h
@@ -160,8 +160,8 @@ const static uint8_t SCK  = 4;		// PIC32 SCK2
 
 /* The Digilent DSPI library uses these ports.
 */
-#define	PIN_DSPI0_SS	17
-#define	PIN_DSPI1_SS	30
+#define	PIN_DSPI0_SS	3
+#define	PIN_DSPI1_SS	4
 
 /* ------------------------------------------------------------ */
 /*					Analog Pins									*/

--- a/hardware/pic32/variants/Fubarino_SDZ/Board_Defs.h
+++ b/hardware/pic32/variants/Fubarino_SDZ/Board_Defs.h
@@ -54,7 +54,7 @@
 ** refer to periperhals on the board generically.
 */
 
-#define	_BOARD_NAME_	"chipKIT WiFire"
+#define	_BOARD_NAME_	"chipKIT Fubarino SDZ"
 
 /* Define the Microcontroller peripherals available on the board.
 */


### PR DESCRIPTION
I had to go in and modify the SD library a bit more than I first thought. However, I cleaned a number of things up in there (like we were trying to do some saving/restoring of SPI interrupts on MAX32, UNO32, uC32 that didn't need to be done, references to SOFTWARE_SPI (we're always using software SPI in this library), etc.). I also added __PIC32_PPS__ as a define we can use anywhere now to trigger code that only needs to exists for PPS parts.

This should all be merged over into chipKIT-core someday too.