### PR TITLE
Fixed variable name conflict with index() function

### DIFF
--- a/build/shared/examples/3.Analog/Smoothing/Smoothing.pde
+++ b/build/shared/examples/3.Analog/Smoothing/Smoothing.pde
@@ -27,7 +27,7 @@
 const int numReadings = 10;
 
 int readings[numReadings];      // the readings from the analog input
-int index = 0;                  // the index of the current reading
+int sampleIndex = 0;                  // the index of the current reading
 int total = 0;                  // the running total
 int average = 0;                // the average
 
@@ -44,18 +44,18 @@ void setup()
 
 void loop() {
   // subtract the last reading:
-  total= total - readings[index];         
+  total= total - readings[sampleIndex];         
   // read from the sensor:  
-  readings[index] = analogRead(inputPin); 
+  readings[sampleIndex] = analogRead(inputPin); 
   // add the reading to the total:
-  total= total + readings[index];       
+  total= total + readings[sampleIndex];       
   // advance to the next position in the array:  
-  index = index + 1;                    
+  sampleIndex = sampleIndex + 1;                    
 
   // if we're at the end of the array...
-  if (index >= numReadings)              
+  if (sampleIndex >= numReadings)              
     // ...wrap around to the beginning: 
-    index = 0;                           
+    sampleIndex = 0;                           
 
   // calculate the average:
   average = total / numReadings;         


### PR DESCRIPTION
We're never going to be able to be compatible with this example because our c library has index() whereas the Arduino one doesn't.  So all we can do is change our example so it works on MPIDE, but there's not a lot we can do about the one in the Arduino IDE.