### PR TITLE
Software Serial library - new version

### DIFF
--- a/hardware/pic32/cores/pic32/cpudefs.h
+++ b/hardware/pic32/cores/pic32/cpudefs.h
@@ -48,7 +48,7 @@
         #define _CPU_NAME_      "32MX110F016B"
         #define FLASHEND        (((16 - 4) * 1024L) - 1)
         #define RAMEND          ((4 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX1XX__
 
@@ -56,7 +56,7 @@
         #define _CPU_NAME_      "32MX110F016C"
         #define FLASHEND        (((16 - 4) * 1024L) - 1)
         #define RAMEND          ((4 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX1XX__
 
@@ -64,7 +64,7 @@
         #define _CPU_NAME_      "32MX110F016D"
         #define FLASHEND        (((16 - 4) * 1024L) - 1)
         #define RAMEND          ((4 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX1XX__
 
@@ -72,7 +72,7 @@
         #define _CPU_NAME_      "32MX120F032B"
         #define FLASHEND        (((32 - 4) * 1024L) - 1)
         #define RAMEND          ((8 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX1XX__
 
@@ -80,7 +80,7 @@
         #define _CPU_NAME_      "32MX120F032C"
         #define FLASHEND        (((32 - 4) * 1024L) - 1)
         #define RAMEND          ((8 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX1XX__
 
@@ -88,7 +88,7 @@
         #define _CPU_NAME_      "32MX120F032D"
         #define FLASHEND        (((32 - 4) * 1024L) - 1)
         #define RAMEND          ((8 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX1XX__
 
@@ -96,7 +96,7 @@
         #define _CPU_NAME_      "32MX130F064B"
         #define FLASHEND        (((64 - 4) * 1024L) - 1)
         #define RAMEND          ((16 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX1XX__
 
@@ -104,7 +104,7 @@
         #define _CPU_NAME_      "32MX130F064C"
         #define FLASHEND        (((64 - 4) * 1024L) - 1)
         #define RAMEND          ((16 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX1XX__
 
@@ -112,7 +112,7 @@
         #define _CPU_NAME_      "32MX130F064D"
         #define FLASHEND        (((64 - 4) * 1024L) - 1)
         #define RAMEND          ((16 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX1XX__
 
@@ -120,7 +120,7 @@
         #define _CPU_NAME_      "32MX150F128B"
         #define FLASHEND        (((128 - 4) * 1024L) - 1)
         #define RAMEND          ((32 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX1XX__
 
@@ -128,7 +128,7 @@
         #define _CPU_NAME_      "32MX150F128C"
         #define FLASHEND        (((128 - 4) * 1024L) - 1)
         #define RAMEND          ((32 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX1XX__
 
@@ -136,7 +136,7 @@
         #define _CPU_NAME_      "32MX150F128D"
         #define FLASHEND        (((128 - 4) * 1024L) - 1)
         #define RAMEND          ((32 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX1XX__
 
@@ -147,7 +147,7 @@
         #define _CPU_NAME_      "32MX210F016B"
         #define FLASHEND        (((16 - 4) * 1024L) - 1)
         #define RAMEND          ((4 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX2XX__
 
@@ -155,7 +155,7 @@
         #define _CPU_NAME_      "32MX210F016C"
         #define FLASHEND        (((16 - 4) * 1024L) - 1)
         #define RAMEND          ((4 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX2XX__
 
@@ -163,7 +163,7 @@
         #define _CPU_NAME_      "32MX210F016D"
         #define FLASHEND        (((16 - 4) * 1024L) - 1)
         #define RAMEND          ((4 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX2XX__
 
@@ -171,7 +171,7 @@
         #define _CPU_NAME_      "32MX220F032B"
         #define FLASHEND        (((32 - 4) * 1024L) - 1)
         #define RAMEND          ((8 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX2XX__
 
@@ -179,7 +179,7 @@
         #define _CPU_NAME_      "32MX220F032C"
         #define FLASHEND        (((32 - 4) * 1024L) - 1)
         #define RAMEND          ((8 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX2XX__
 
@@ -187,7 +187,7 @@
         #define _CPU_NAME_      "32MX220F032D"
         #define FLASHEND        (((32 - 4) * 1024L) - 1)
         #define RAMEND          ((8 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX2XX__
 
@@ -195,7 +195,7 @@
         #define _CPU_NAME_      "32MX230F064B"
         #define FLASHEND        (((64 - 4) * 1024L) - 1)
         #define RAMEND          ((16 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX2XX__
 
@@ -203,7 +203,7 @@
         #define _CPU_NAME_      "32MX230F064C"
         #define FLASHEND        (((64 - 4) * 1024L) - 1)
         #define RAMEND          ((16 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX2XX__
 
@@ -211,7 +211,7 @@
         #define _CPU_NAME_      "32MX230F064D"
         #define FLASHEND        (((64 - 4) * 1024L) - 1)
         #define RAMEND          ((16 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX2XX__
 
@@ -219,7 +219,7 @@
         #define _CPU_NAME_      "32MX250F128B"
         #define FLASHEND        (((128 - 4) * 1024L) - 1)
         #define RAMEND          ((32 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  28
         #define __PIC32MX2XX__
 
@@ -227,7 +227,7 @@
         #define _CPU_NAME_      "32MX250F128C"
         #define FLASHEND        (((128 - 4) * 1024L) - 1)
         #define RAMEND          ((32 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  36
         #define __PIC32MX2XX__
 
@@ -235,7 +235,7 @@
         #define _CPU_NAME_      "32MX250F128D"
         #define FLASHEND        (((128 - 4) * 1024L) - 1)
         #define RAMEND          ((32 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  44
         #define __PIC32MX2XX__
 
@@ -587,12 +587,12 @@
 
     //************************************************************************
     //*  MZ  EC series
-		
+        
     #elif defined(__32MZ1024ECG064__)
         #define _CPU_NAME_      "32MZ1024ECG064"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -600,7 +600,7 @@
         #define _CPU_NAME_      "32MZ1024ECH064"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -608,7 +608,7 @@
         #define _CPU_NAME_      "32MZ1024ECM064"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -616,7 +616,7 @@
         #define _CPU_NAME_      "32MZ2048ECG064"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -624,7 +624,7 @@
         #define _CPU_NAME_      "32MZ2048ECH064"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -632,7 +632,7 @@
         #define _CPU_NAME_      "32MZ2048ECM064"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -640,7 +640,7 @@
         #define _CPU_NAME_      "32MZ1024ECG100"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
  
@@ -648,7 +648,7 @@
         #define _CPU_NAME_      "32MZ1024ECH100"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -656,7 +656,7 @@
         #define _CPU_NAME_      "32MZ1024ECM100"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
  
@@ -664,7 +664,7 @@
         #define _CPU_NAME_      "32MZ2048ECG100"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -672,7 +672,7 @@
         #define _CPU_NAME_      "32MZ2048ECH100"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -680,7 +680,7 @@
         #define _CPU_NAME_      "32MZ2048ECM100"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -688,7 +688,7 @@
         #define _CPU_NAME_      "32MZ1024ECG124"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -696,7 +696,7 @@
         #define _CPU_NAME_      "32MZ1024ECH124"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -704,7 +704,7 @@
         #define _CPU_NAME_      "32MZ1024ECM124"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -712,7 +712,7 @@
         #define _CPU_NAME_      "32MZ2048ECG124"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -720,7 +720,7 @@
         #define _CPU_NAME_      "32MZ2048ECH124"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -728,7 +728,7 @@
         #define _CPU_NAME_      "32MZ2048EC124"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -736,7 +736,7 @@
         #define _CPU_NAME_      "32MZ1024ECG144"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
  
@@ -744,7 +744,7 @@
         #define _CPU_NAME_      "32MZ1024ECH144"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
@@ -752,7 +752,7 @@
         #define _CPU_NAME_      "32MZ1024ECM144"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
  
@@ -760,7 +760,7 @@
         #define _CPU_NAME_      "32MZ2048ECG144"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
@@ -768,7 +768,7 @@
         #define _CPU_NAME_      "32MZ2048ECH144"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
@@ -776,7 +776,7 @@
         #define _CPU_NAME_      "32MZ2048ECM144"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
  
@@ -784,7 +784,7 @@
         #define _CPU_NAME_      "32MZ0512ECE064"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
  
@@ -792,7 +792,7 @@
         #define _CPU_NAME_      "32MZ0512ECF064"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -800,7 +800,7 @@
         #define _CPU_NAME_      "32MZ0512ECK064"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
  
@@ -808,7 +808,7 @@
         #define _CPU_NAME_      "32MZ1024ECE064"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -816,7 +816,7 @@
         #define _CPU_NAME_      "32MZ1024ECF064"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
 
@@ -824,7 +824,7 @@
         #define _CPU_NAME_      "32MZ1024ECK064"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
  
@@ -832,7 +832,7 @@
         #define _CPU_NAME_      "32MZ0512ECE100"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -840,7 +840,7 @@
         #define _CPU_NAME_      "32MZ0512ECF100"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -848,7 +848,7 @@
         #define _CPU_NAME_      "32MZ0512ECK100"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -856,7 +856,7 @@
         #define _CPU_NAME_      "32MZ1024ECE100"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -864,7 +864,7 @@
         #define _CPU_NAME_      "32MZ1024ECF100"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
 
@@ -872,7 +872,7 @@
         #define _CPU_NAME_      "32MZ1024ECK100"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
  
@@ -880,7 +880,7 @@
         #define _CPU_NAME_      "32MZ0512ECE124"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -888,7 +888,7 @@
         #define _CPU_NAME_      "32MZ0512ECF124"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
  
@@ -896,7 +896,7 @@
         #define _CPU_NAME_      "32MZ0512ECK124"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
  
@@ -904,7 +904,7 @@
         #define _CPU_NAME_      "32MZ1024ECE124"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -912,7 +912,7 @@
         #define _CPU_NAME_      "32MZ1024ECF124"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -920,7 +920,7 @@
         #define _CPU_NAME_      "32MZ1024ECK124"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
 
@@ -928,7 +928,7 @@
         #define _CPU_NAME_      "32MZ0512ECE144"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
@@ -936,7 +936,7 @@
         #define _CPU_NAME_      "32MZ0512ECF144"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
  
@@ -944,7 +944,7 @@
         #define _CPU_NAME_      "32MZ0512ECK144"
         #define FLASHEND        (((512 - 4) * 1024L) - 1)
         #define RAMEND          ((128 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
@@ -952,7 +952,7 @@
         #define _CPU_NAME_      "32MZ1024ECE144"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
@@ -960,7 +960,7 @@
         #define _CPU_NAME_      "32MZ1024ECF144"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
@@ -968,18 +968,18 @@
         #define _CPU_NAME_      "32MZ1024ECK144"
         #define FLASHEND        (((1024 - 4) * 1024L) - 1)
         #define RAMEND          ((256 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
 
-	//************************************************************************
+    //************************************************************************
     //*   MZ   EF series
 
     #elif defined(__32MZ2048EFG064__)
         #define _CPU_NAME_      "32MZ2048EFG064"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -988,7 +988,7 @@
         #define _CPU_NAME_      "32MZ2048EFG100"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -997,7 +997,7 @@
         #define _CPU_NAME_      "32MZ2048EFG124"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -1006,7 +1006,7 @@
         #define _CPU_NAME_      "32MZ2048EFG144"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -1015,7 +1015,7 @@
         #define _CPU_NAME_      "32MZ2048EFH064"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -1024,7 +1024,7 @@
         #define _CPU_NAME_      "32MZ2048EFH100"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -1033,7 +1033,7 @@
         #define _CPU_NAME_      "32MZ2048EFH124"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -1042,7 +1042,7 @@
         #define _CPU_NAME_      "32MZ2048EFH144"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -1051,7 +1051,7 @@
         #define _CPU_NAME_      "32MZ2048EFM064"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  64
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -1060,7 +1060,7 @@
         #define _CPU_NAME_      "32MZ2048EFM100"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  100
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -1069,7 +1069,7 @@
         #define _CPU_NAME_      "32MZ2048EFM124"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  124
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -1078,7 +1078,7 @@
         #define _CPU_NAME_      "32MZ2048EFM144"
         #define FLASHEND        (((2048 - 4) * 1024L) - 1)
         #define RAMEND          ((512 * 1024L) - 1)
-		#define __PIC32_PPS__
+        #define __PIC32_PPS__
         #define __PIC32_PINS__  144
         #define __PIC32MZXX__
         #define __PIC32MZEFADC__
@@ -1088,12 +1088,12 @@
     #endif
 #endif //defined(__PIC32MX__) || defined(__PIC32MZ__)
 
-// Set up MZ ADC type	
+// Set up MZ ADC type   
 #if defined(__PIC32MZ__)
-	// do we have EF or EC ADCs
-	#ifndef __PIC32MZEFADC__
-		#define __PIC32MZECADC__
-	#endif
+    // do we have EF or EC ADCs
+    #ifndef __PIC32MZEFADC__
+        #define __PIC32MZECADC__
+    #endif
 #endif
 
 //************************************************************************

--- a/hardware/pic32/cores/pic32/p32_defs.h
+++ b/hardware/pic32/cores/pic32/p32_defs.h
@@ -1,43 +1,43 @@
 //************************************************************************
-//*	p32_defs.h
+//* p32_defs.h
 //*
-//*	chipKIT core files for PIC32
-//*		Copyright (c) 2011 by Digilent Inc.
-//*	
+//* chipKIT core files for PIC32
+//*     Copyright (c) 2011 by Digilent Inc.
+//* 
 //************************************************************************
-//*		Author: Gene Apperson
-//*		Copyright (c) 2011, Digilent Inc, All rights reserved
+//*     Author: Gene Apperson
+//*     Copyright (c) 2011, Digilent Inc, All rights reserved
 //************************************************************************
 //*
 //* This file contains hardware dependent symbol and data type declarations
 //* for the PIC32 microcontroller.
 //*
 //************************************************************************
-//*	This file is part of the core system for the chipKIT version
+//* This file is part of the core system for the chipKIT version
 //* of the Arduino code base. It defines various generic symbols
 //* describing the Microchip PIC32 devices.
-//*	
-//*	This library is free software; you can redistribute it and/or
-//*	modify it under the terms of the GNU Lesser General Public
-//*	License as published by the Free Software Foundation; either
-//*	version 2.1 of the License, or (at your option) any later version.
-//*	
-//*	This library is distributed in the hope that it will be useful,
-//*	but WITHOUT ANY WARRANTY; without even the implied warranty of
-//*	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-//*	Lesser General Public License for more details.
-//*	
-//*	You should have received a copy of the GNU Lesser General
-//*	Public License along with this library; if not, write to the
-//*	Free Software Foundation, Inc., 59 Temple Place, Suite 330,
-//*	Boston, MA  02111-1307  USA
+//* 
+//* This library is free software; you can redistribute it and/or
+//* modify it under the terms of the GNU Lesser General Public
+//* License as published by the Free Software Foundation; either
+//* version 2.1 of the License, or (at your option) any later version.
+//* 
+//* This library is distributed in the hope that it will be useful,
+//* but WITHOUT ANY WARRANTY; without even the implied warranty of
+//* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//* Lesser General Public License for more details.
+//* 
+//* You should have received a copy of the GNU Lesser General
+//* Public License along with this library; if not, write to the
+//* Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+//* Boston, MA  02111-1307  USA
 //************************************************************************
-//*	Edit History
+//* Edit History
 //************************************************************************
-//*	Oct 2, 2011	<Gene Apperson> created
-//*	Jul 26, 2012 <GeneApperson> Added PPS support for PIC32MX1xx/MX2xx devices
+//* Oct 2, 2011 <Gene Apperson> created
+//* Jul 26, 2012 <GeneApperson> Added PPS support for PIC32MX1xx/MX2xx devices
 //* Feb  6, 2013 <GeneApperson> Added bit definitions for several peripherals
-//*	Feb 17, 2012	<KeithV> Added PPS support for MZ devices
+//* Feb 17, 2012    <KeithV> Added PPS support for MZ devices
 //************************************************************************
 
 
@@ -49,13 +49,13 @@
 #include <inttypes.h>
 
 /* ------------------------------------------------------------ */
-/*				Misc. Declarations								*/
+/*              Misc. Declarations                              */
 /* ------------------------------------------------------------ */
 
-#define	FLASH_SPEED_HZ          30000000
+#define FLASH_SPEED_HZ          30000000
 
 /* ------------------------------------------------------------ */
-/*				Register Declarations							*/
+/*              Register Declarations                           */
 /* ------------------------------------------------------------ */
 
 typedef union {
@@ -87,10 +87,10 @@ typedef union {
 ** most special function registers.
 */
 typedef struct {
-	volatile uint32_t	reg;
-	volatile uint32_t	clr;
-	volatile uint32_t	set;
-	volatile uint32_t	inv;
+    volatile uint32_t   reg;
+    volatile uint32_t   clr;
+    volatile uint32_t   set;
+    volatile uint32_t   inv;
 } p32_regset;
 
 /* This structure describes the register layout for a buffer
@@ -98,19 +98,19 @@ typedef struct {
 ** registers.
 */
 typedef struct {
-	volatile uint32_t	reg;
-	volatile uint32_t	rsv1;
-	volatile uint32_t	rsv2;
-	volatile uint32_t	rsv3;
+    volatile uint32_t   reg;
+    volatile uint32_t   rsv1;
+    volatile uint32_t   rsv2;
+    volatile uint32_t   rsv3;
 } p32_regbuf;
 
 /* This structure describes the register layout of an I/O port.
 */
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 typedef struct {
     union
     {
-	    volatile p32_regset ansel;
+        volatile p32_regset ansel;
         struct
         {
             volatile __REGbits_t ANSELxbits;
@@ -121,7 +121,7 @@ typedef struct {
     };
     union
     {
-	    volatile p32_regset	tris;
+        volatile p32_regset tris;
         struct
         {
             volatile __REGbits_t TRISxbits;
@@ -132,7 +132,7 @@ typedef struct {
     };
     union
     {
-	    volatile p32_regset	port;
+        volatile p32_regset port;
         struct
         {
             volatile __REGbits_t PORTxbits;
@@ -143,7 +143,7 @@ typedef struct {
     };
     union
     {
-	    volatile p32_regset	lat;
+        volatile p32_regset lat;
         struct
         {
             volatile __REGbits_t LATxbits;
@@ -154,7 +154,7 @@ typedef struct {
     };
     union
     {
-	    volatile p32_regset	odc;
+        volatile p32_regset odc;
         struct
         {
             volatile __REGbits_t ODCxbits;
@@ -165,7 +165,7 @@ typedef struct {
     };
     union
     {
-	    volatile p32_regset cnpu;
+        volatile p32_regset cnpu;
         struct
         {
             volatile __REGbits_t CNPUxbits;
@@ -177,7 +177,7 @@ typedef struct {
 
     union
     {
-	    volatile p32_regset cnpd;
+        volatile p32_regset cnpd;
         struct
         {
             volatile __REGbits_t CNPDxbits;
@@ -186,16 +186,45 @@ typedef struct {
             volatile __REGbits_t CNPDxINV;
         };
     };
-
-	volatile p32_regset cncon;
-	volatile p32_regset cnen;
-	volatile p32_regset cnstat;
+    union
+    {
+        volatile p32_regset cncon;
+        struct
+        {
+            volatile __REGbits_t CNCONxbits;
+            volatile __REGbits_t CNCONxCLR;
+            volatile __REGbits_t CNCONxSET;
+            volatile __REGbits_t CNCONxINV;
+        };
+    };
+    union 
+    {
+        volatile p32_regset cnen;
+        struct
+        {
+            volatile __REGbits_t CNENxbits;
+            volatile __REGbits_t CNENxCLR;
+            volatile __REGbits_t CNENxSET;
+            volatile __REGbits_t CNENxINV;
+        };
+    };
+    union
+    {
+        volatile p32_regset cnstat;
+        struct
+        {
+            volatile __REGbits_t CNSTATxbits;
+            volatile __REGbits_t CNSTATxCLR;
+            volatile __REGbits_t CNSTATxSET;
+            volatile __REGbits_t CNSTATxINV;
+        };
+    };
 } p32_ioport;
-#else
+#else       // Non-PPS PIC32s have much simpler I/O register structures
 typedef struct {
     union
     {
-	    volatile p32_regset	tris;
+        volatile p32_regset tris;
         struct
         {
             volatile __REGbits_t TRISxbits;
@@ -206,7 +235,7 @@ typedef struct {
     };
     union
     {
-	    volatile p32_regset	port;
+        volatile p32_regset port;
         struct
         {
             volatile __REGbits_t PORTxbits;
@@ -217,7 +246,7 @@ typedef struct {
     };
     union
     {
-	    volatile p32_regset	lat;
+        volatile p32_regset lat;
         struct
         {
             volatile __REGbits_t LATxbits;
@@ -228,7 +257,7 @@ typedef struct {
     };
     union
     {
-	    volatile p32_regset	odc;
+        volatile p32_regset odc;
         struct
         {
             volatile __REGbits_t ODCxbits;
@@ -246,21 +275,21 @@ typedef struct {
     union
     {
         volatile __U1MODEbits_t uartMode;
-	    volatile p32_regset	    uxMode;
+        volatile p32_regset     uxMode;
     };
     union
     {
-	    volatile __U1STAbits_t	uartSta;
-	    volatile p32_regset	    uxSta;
+        volatile __U1STAbits_t  uartSta;
+        volatile p32_regset     uxSta;
     };
-	volatile p32_regbuf	uxTx;
-	volatile p32_regbuf	uxRx;
-	volatile p32_regset	uxBrg;
+    volatile p32_regbuf uxTx;
+    volatile p32_regbuf uxRx;
+    volatile p32_regset uxBrg;
 } p32_uart;
 
 /* UxMODE - Define bits in UART mode port
 */
-#define	_UARTMODE_ON	15
+#define _UARTMODE_ON    15
 #define _UARTMODE_BRGH  3
 #define _UARTMODE_PDSEL 1
 
@@ -268,10 +297,10 @@ typedef struct {
 */
 #define _UARTSTA_ADM_EN 24
 #define _UARTSTA_ADDR   16
-#define	_UARTSTA_URXEN	12
-#define	_UARTSTA_UTXEN	10
+#define _UARTSTA_URXEN  12
+#define _UARTSTA_UTXEN  10
 #define _UARTSTA_UTXBF  9
-#define	_UARTSTA_TMRT	8
+#define _UARTSTA_TMRT   8
 #define _UARTSTA_ADDEN  5
 
 /* Structure for the registers of a PIC32 SPI controller
@@ -280,34 +309,34 @@ typedef struct {
     union
     {
         volatile __SPI2CONbits_t    spiCon;
-	    volatile p32_regset         sxCon;
+        volatile p32_regset         sxCon;
     };
     union
     {
-	    volatile __SPI2STATbits_t   spiStat;
-	    volatile p32_regset         sxStat;
+        volatile __SPI2STATbits_t   spiStat;
+        volatile p32_regset         sxStat;
     };
-	volatile p32_regbuf sxBuf;
-	volatile p32_regset sxBrg;
+    volatile p32_regbuf sxBuf;
+    volatile p32_regset sxBrg;
 } p32_spi;
 
-/*	SPIxCON - Define bits in the SPI control port
+/*  SPIxCON - Define bits in the SPI control port
 */
-#define _SPICON_ON		15
-#define _SPICON_MODE32		11
-#define _SPICON_MODE16		10
-#define _SPICON_SMP		9
-#define	_SPICON_CKE		8
-#define _SPICON_CKP		6
-#define _SPICON_MSTEN	5
+#define _SPICON_ON      15
+#define _SPICON_MODE32      11
+#define _SPICON_MODE16      10
+#define _SPICON_SMP     9
+#define _SPICON_CKE     8
+#define _SPICON_CKP     6
+#define _SPICON_MSTEN   5
 
-/*	SPIxSTAT - Define symbols in the SPI status port
+/*  SPIxSTAT - Define symbols in the SPI status port
 */
-#define	_SPISTAT_SPIROV	6
+#define _SPISTAT_SPIROV 6
 #define _SPISTAT_SPIRBE 5
-#define	_SPISTAT_SPITBE	3
+#define _SPISTAT_SPITBE 3
 #define _SPISTAT_SPITBF 1
-#define _SPISTAT_SPIRBF	0
+#define _SPISTAT_SPIRBF 0
 
 /* This structure defines the registers for a PIC32 I2C port.
 */
@@ -315,60 +344,60 @@ typedef struct {
     union
     {
         volatile __I2C1CONbits_t    i2cCon;
-	    volatile p32_regset	        ixCon;
+        volatile p32_regset         ixCon;
     };
     union
     {
         volatile __I2C1STATbits_t   i2cStat;
-	    volatile p32_regset         ixStat;
+        volatile p32_regset         ixStat;
     };
-	volatile p32_regset ixAdd;
-	volatile p32_regset ixMsk;
-	volatile p32_regset ixBrg;
-	volatile p32_regset ixTrn;
-	volatile p32_regbuf ixRcv;
+    volatile p32_regset ixAdd;
+    volatile p32_regset ixMsk;
+    volatile p32_regset ixBrg;
+    volatile p32_regset ixTrn;
+    volatile p32_regbuf ixRcv;
 } p32_i2c;
 
 /* I2CxCON - Define symbols for the I2C control port bits
 */
-#define	_I2CCON_ON		15
-#define	_I2CCON_SIDL	13
-#define	_I2CCON_SCLREL	12
-#define _I2CCON_STRICT	11
-#define	_I2CCON_A10M	10
-#define	_I2CCON_DISSLW	9
-#define	_I2CCON_SMEN	8
-#define	_I2CCON_GCEN	7
-#define	_I2CCON_STREN	6
-#define	_I2CCON_ACKDT	5
-#define	_I2CCON_ACKEN	4
-#define	_I2CCON_RCEN	3
-#define	_I2CCON_PEN		2
-#define	_I2CCON_RSEN	1
-#define	_I2CCON_SEN		0
+#define _I2CCON_ON      15
+#define _I2CCON_SIDL    13
+#define _I2CCON_SCLREL  12
+#define _I2CCON_STRICT  11
+#define _I2CCON_A10M    10
+#define _I2CCON_DISSLW  9
+#define _I2CCON_SMEN    8
+#define _I2CCON_GCEN    7
+#define _I2CCON_STREN   6
+#define _I2CCON_ACKDT   5
+#define _I2CCON_ACKEN   4
+#define _I2CCON_RCEN    3
+#define _I2CCON_PEN     2
+#define _I2CCON_RSEN    1
+#define _I2CCON_SEN     0
 
 /* I2CSTAT - Define symbols for the I2C status port bits
 */
-#define	_I2CSTAT_ACKSTAT	15
-#define	_I2CSTAT_TRSTAT		14
-#define	_I2CSTAT_BCL		10
-#define	_I2CSTAT_GCSTAT		9
-#define	_I2CSTAT_ADD10		8
-#define	_I2CSTAT_IWCOL		7
-#define	_I2CSTAT_I2COV		6
-#define	_I2CSTAT_DA			5
-#define	_I2CSTAT_P			4
-#define	_I2CSTAT_S			3
-#define	_I2CSTAT_RW			2
-#define	_I2CSTAT_RBF		1
-#define	_I2CSTAT_TBF		0
+#define _I2CSTAT_ACKSTAT    15
+#define _I2CSTAT_TRSTAT     14
+#define _I2CSTAT_BCL        10
+#define _I2CSTAT_GCSTAT     9
+#define _I2CSTAT_ADD10      8
+#define _I2CSTAT_IWCOL      7
+#define _I2CSTAT_I2COV      6
+#define _I2CSTAT_DA         5
+#define _I2CSTAT_P          4
+#define _I2CSTAT_S          3
+#define _I2CSTAT_RW         2
+#define _I2CSTAT_RBF        1
+#define _I2CSTAT_TBF        0
 
 /* This structure defines the registers for a PIC32 Timer.
 */
 typedef struct {
-	volatile p32_regset tmxCon;
-	volatile p32_regset tmxTmr;
-	volatile p32_regset tmxPr;
+    volatile p32_regset tmxCon;
+    volatile p32_regset tmxTmr;
+    volatile p32_regset tmxPr;
 } p32_timer;
 
 /* Define bits in the timer control register.
@@ -376,209 +405,209 @@ typedef struct {
 ** than Type B timers (timer2 - timer5)
 */
 // Type A timer - Timer1
-#define _BN_TACON_ON		15
-#define	_BN_TACON_FRZ		14
-#define	_BN_TACON_SIDL		13
-#define	_BN_TACON_TWDIS		12
-#define	_BN_TACON_TWIP		11
-#define	_BN_TACON_TGATE		7
-#define _BN_TACON_TCKPS		4
-#define	_BN_TACON_TSYNC		2
-#define _BN_TACON_TCS		1
+#define _BN_TACON_ON        15
+#define _BN_TACON_FRZ       14
+#define _BN_TACON_SIDL      13
+#define _BN_TACON_TWDIS     12
+#define _BN_TACON_TWIP      11
+#define _BN_TACON_TGATE     7
+#define _BN_TACON_TCKPS     4
+#define _BN_TACON_TSYNC     2
+#define _BN_TACON_TCS       1
 
-#define TACON_ON			(1 << _BN_TACON_ON)
-#define TACON_OFF			(0)
-#define	TACON_FRZ_ON		(1 << _BN_TACON_FRZ)
-#define	TACON_FRZ_OFF		(0)
-#define	TACON_IDLE_STOP		(1 << _BN_TACON_SIDL)
-#define	TACON_IDLE_RUN		(0)
-#define	TACON_TWDIS_ON		(1 << _BN_TACON_TWDIS)
-#define	TACON_TWDIS_OFF		(0)
-#define	TACON_TWIP			(1 << _BN_TACON_TWIP)
-#define	TACON_TGATE_ON		(1 << _BN_TACON_TGATE)
-#define	TACON_TGATE_OFF		(0)
-#define	TACON_TSYNC_ON		(1 << _BN_TACON_TSYNC)
-#define	TACON_TSYNC_OFF		(0)
+#define TACON_ON            (1 << _BN_TACON_ON)
+#define TACON_OFF           (0)
+#define TACON_FRZ_ON        (1 << _BN_TACON_FRZ)
+#define TACON_FRZ_OFF       (0)
+#define TACON_IDLE_STOP     (1 << _BN_TACON_SIDL)
+#define TACON_IDLE_RUN      (0)
+#define TACON_TWDIS_ON      (1 << _BN_TACON_TWDIS)
+#define TACON_TWDIS_OFF     (0)
+#define TACON_TWIP          (1 << _BN_TACON_TWIP)
+#define TACON_TGATE_ON      (1 << _BN_TACON_TGATE)
+#define TACON_TGATE_OFF     (0)
+#define TACON_TSYNC_ON      (1 << _BN_TACON_TSYNC)
+#define TACON_TSYNC_OFF     (0)
 
-#define TACON_SRC_INT		(0 << _BN_TACON_TCS)
-#define TACON_SRC_EXT		(1 << _BN_TACON_TCS)
+#define TACON_SRC_INT       (0 << _BN_TACON_TCS)
+#define TACON_SRC_EXT       (1 << _BN_TACON_TCS)
 
-#define	TACON_PS_MASK		(3 << _BN_TACON_TCKPS)
-#define	TACON_PS_1			(0 << _BN_TACON_TCKPS)
-#define TACON_PS_8			(1 << _BN_TACON_TCKPS)
-#define	TACON_PS_64			(2 << _BN_TACON_TCKPS)
-#define	TACON_PS_256		(3 << _BN_TACON_TCKPS)
+#define TACON_PS_MASK       (3 << _BN_TACON_TCKPS)
+#define TACON_PS_1          (0 << _BN_TACON_TCKPS)
+#define TACON_PS_8          (1 << _BN_TACON_TCKPS)
+#define TACON_PS_64         (2 << _BN_TACON_TCKPS)
+#define TACON_PS_256        (3 << _BN_TACON_TCKPS)
 
 // Type B timer - Timer2-Timer5
-#define	_BN_TBCON_ON		15
-#define	_BN_TBCON_FRZ		14
-#define	_BN_TBCON_SIDL		13
-#define	_BN_TBCON_TGATE		7
-#define	_BN_TBCON_TCKPS		4
-#define	_BN_TBCON_T32		3
-#define	_BN_TBCON_TCS		1
+#define _BN_TBCON_ON        15
+#define _BN_TBCON_FRZ       14
+#define _BN_TBCON_SIDL      13
+#define _BN_TBCON_TGATE     7
+#define _BN_TBCON_TCKPS     4
+#define _BN_TBCON_T32       3
+#define _BN_TBCON_TCS       1
 
-#define	TBCON_ON			(1 << _BN_TBCON_ON)
-#define	TBCON_OFF			(0)
-#define	TBCON_FRZ_ON		(1 << _BN_TBCON_FRZ)
-#define	TBCON_FRZ_OFF		(0)
-#define	TBCON_IDLE_STOP		(1 << _BN_TBCON_SIDL)
-#define	TBCON_IDLE_RUN		(0)
-#define	TBCON_TGATE_ON		(1 << _BN_TBCON_TGATE)
-#define	TBCON_TGATE_OFF		(0)
+#define TBCON_ON            (1 << _BN_TBCON_ON)
+#define TBCON_OFF           (0)
+#define TBCON_FRZ_ON        (1 << _BN_TBCON_FRZ)
+#define TBCON_FRZ_OFF       (0)
+#define TBCON_IDLE_STOP     (1 << _BN_TBCON_SIDL)
+#define TBCON_IDLE_RUN      (0)
+#define TBCON_TGATE_ON      (1 << _BN_TBCON_TGATE)
+#define TBCON_TGATE_OFF     (0)
 
-#define TBCON_PS_MASK		(7 << _BN_TBCON_TCKPS)
-#define	TBCON_PS_1			(0 << _BN_TBCON_TCKPS)
-#define	TBCON_PS_2			(1 << _BN_TBCON_TCKPS)
-#define TBCON_PS_4			(2 << _BN_TBCON_TCKPS)
-#define TBCON_PS_8			(3 << _BN_TBCON_TCKPS)
-#define TBCON_PS_16			(4 << _BN_TBCON_TCKPS)
-#define	TBCON_PS_32			(5 << _BN_TBCON_TCKPS)
-#define TBCON_PS_64			(6 << _BN_TBCON_TCKPS)
-#define TBCON_PS_256		(7 << _BN_TBCON_TCKPS)
+#define TBCON_PS_MASK       (7 << _BN_TBCON_TCKPS)
+#define TBCON_PS_1          (0 << _BN_TBCON_TCKPS)
+#define TBCON_PS_2          (1 << _BN_TBCON_TCKPS)
+#define TBCON_PS_4          (2 << _BN_TBCON_TCKPS)
+#define TBCON_PS_8          (3 << _BN_TBCON_TCKPS)
+#define TBCON_PS_16         (4 << _BN_TBCON_TCKPS)
+#define TBCON_PS_32         (5 << _BN_TBCON_TCKPS)
+#define TBCON_PS_64         (6 << _BN_TBCON_TCKPS)
+#define TBCON_PS_256        (7 << _BN_TBCON_TCKPS)
 
-#define	TBCON_MODE32		(1 << _BN_TBCON_T32)
-#define	TBCON_MODE16		(0)
-#define TBCON_SRC_EXT		(1 << _BN_TBCON_TCS)
-#define TBCON_SRC_INT		(0)
+#define TBCON_MODE32        (1 << _BN_TBCON_T32)
+#define TBCON_MODE16        (0)
+#define TBCON_SRC_EXT       (1 << _BN_TBCON_TCS)
+#define TBCON_SRC_INT       (0)
 
 /* This structure defines the registers for a PIC32 Input Capture.
 */
 typedef struct {
-	volatile p32_regset icxCon;
-	volatile p32_regbuf icxBuf;
+    volatile p32_regset icxCon;
+    volatile p32_regbuf icxBuf;
 } p32_ic;
 
 /* Define bits in the incput capture control register
 */
-#define	_BN_ICCON_ON		15
-#define	_BN_ICCON_FRZ		14
-#define	_BN_ICCON_SIDL		13
-#define	_BN_ICCON_FEDGE		9
-#define	_BN_ICCON_C32		8
-#define	_BN_ICCON_ICTMR		7
-#define	_BN_ICCON_ICI		5
-#define	_BN_ICCON_ICOV		4
-#define	_BN_ICCON_ICBNE		3
-#define	_BN_ICCON_ICM		0
+#define _BN_ICCON_ON        15
+#define _BN_ICCON_FRZ       14
+#define _BN_ICCON_SIDL      13
+#define _BN_ICCON_FEDGE     9
+#define _BN_ICCON_C32       8
+#define _BN_ICCON_ICTMR     7
+#define _BN_ICCON_ICI       5
+#define _BN_ICCON_ICOV      4
+#define _BN_ICCON_ICBNE     3
+#define _BN_ICCON_ICM       0
 
-#define	ICCON_ON			(1 << _BN_ICCON_ON)
-#define	ICCON_OFF			(0)
-#define	ICCON_FRZ_ON		(1 << _BN_ICCON_FRZ)
-#define	ICCON_FRZ_OFF		(0)
-#define	ICCON_IDLE_STOP		(1 << _BN_ICCON_SIDL)
-#define	ICCON_IDLE_RUN		(0)
-#define	ICCON_FEDGE_RISING	(1 << _BN_ICCON_FEDGE)
-#define	ICCON_FEDGE_FALLING	(0)
-#define	ICCON_WIDTH_32		(1 << _BN_ICCON_C32)
-#define	ICCON_WIDTH_16		(0)
-#define	ICCON_SOURCE_TIMER2	(1 << _BN_ICCON_ICTMR)
-#define	ICCON_SOURCE_TIMER3	(0)
-#define	ICCON_INT_FOURTH_EVENT	(3 << _BN_ICCON_ICI)
-#define	ICCON_INT_THIRD_EVENT	(2 << _BN_ICCON_ICI)
-#define	ICCON_INT_SECOND_EVENT	(1 << _BN_ICCON_ICI)
-#define	ICCON_INT_EVERY_EVENT	(0 << _BN_ICCON_ICI)
-#define	ICCON_OVERFLOW		(1 << _BN_ICCON_ICOV)
-#define	ICCON_ICBNE			(1 << _BN_ICCON_ICBNE)
-#define	ICCON_ICM_INTERRUPT		(7 << _BN_ICCON_ICM)
-#define	ICCON_ICM_EVERY_EDGE	(6 << _BN_ICCON_ICM)
-#define	ICCON_ICM_RISING_16		(5 << _BN_ICCON_ICM)
-#define	ICCON_ICM_RISING_4		(4 << _BN_ICCON_ICM)
-#define	ICCON_ICM_RISING_EDGE	(3 << _BN_ICCON_ICM)
-#define	ICCON_ICM_FALLING_EDGE	(2 << _BN_ICCON_ICM)
-#define	ICCON_ICM_EDGE_DETECT	(1 << _BN_ICCON_ICM)
-#define	ICCON_ICM_DISABLE		(0 << _BN_ICCON_ICM)
+#define ICCON_ON            (1 << _BN_ICCON_ON)
+#define ICCON_OFF           (0)
+#define ICCON_FRZ_ON        (1 << _BN_ICCON_FRZ)
+#define ICCON_FRZ_OFF       (0)
+#define ICCON_IDLE_STOP     (1 << _BN_ICCON_SIDL)
+#define ICCON_IDLE_RUN      (0)
+#define ICCON_FEDGE_RISING  (1 << _BN_ICCON_FEDGE)
+#define ICCON_FEDGE_FALLING (0)
+#define ICCON_WIDTH_32      (1 << _BN_ICCON_C32)
+#define ICCON_WIDTH_16      (0)
+#define ICCON_SOURCE_TIMER2 (1 << _BN_ICCON_ICTMR)
+#define ICCON_SOURCE_TIMER3 (0)
+#define ICCON_INT_FOURTH_EVENT  (3 << _BN_ICCON_ICI)
+#define ICCON_INT_THIRD_EVENT   (2 << _BN_ICCON_ICI)
+#define ICCON_INT_SECOND_EVENT  (1 << _BN_ICCON_ICI)
+#define ICCON_INT_EVERY_EVENT   (0 << _BN_ICCON_ICI)
+#define ICCON_OVERFLOW      (1 << _BN_ICCON_ICOV)
+#define ICCON_ICBNE         (1 << _BN_ICCON_ICBNE)
+#define ICCON_ICM_INTERRUPT     (7 << _BN_ICCON_ICM)
+#define ICCON_ICM_EVERY_EDGE    (6 << _BN_ICCON_ICM)
+#define ICCON_ICM_RISING_16     (5 << _BN_ICCON_ICM)
+#define ICCON_ICM_RISING_4      (4 << _BN_ICCON_ICM)
+#define ICCON_ICM_RISING_EDGE   (3 << _BN_ICCON_ICM)
+#define ICCON_ICM_FALLING_EDGE  (2 << _BN_ICCON_ICM)
+#define ICCON_ICM_EDGE_DETECT   (1 << _BN_ICCON_ICM)
+#define ICCON_ICM_DISABLE       (0 << _BN_ICCON_ICM)
 
 /* This structure defines the registers for a PIC32 Output Compare.
 */
 typedef struct {
-	volatile p32_regset ocxCon;
-	volatile p32_regset ocxR;
-	volatile p32_regset ocxRs;
+    volatile p32_regset ocxCon;
+    volatile p32_regset ocxR;
+    volatile p32_regset ocxRs;
 } p32_oc;
 
 /* Define bits in the output compare control register
 */
-#define _BN_OCCON_ON		15
-#define	_BN_OCCON_SIDL		13
-#define _BN_OCCON_OC32		5
-#define	_BN_OCCON_OCFLT		4
-#define _BN_OCCON_OCTSEL	3
-#define	_BN_OCCON_OCM		0
+#define _BN_OCCON_ON        15
+#define _BN_OCCON_SIDL      13
+#define _BN_OCCON_OC32      5
+#define _BN_OCCON_OCFLT     4
+#define _BN_OCCON_OCTSEL    3
+#define _BN_OCCON_OCM       0
 
 #ifndef OCCON_ON
-#define OCCON_ON			(1 << _BN_OCCON_ON)
+#define OCCON_ON            (1 << _BN_OCCON_ON)
 #endif
-#define OCCON_OFF			(0)
-#define	OCCON_IDLE_STOP		(1 << _BN_OCCON_SIDL)
-#define	OCCON_IDLE_RUN		(0)
-#define OCCON_MODE32		(1 << _BN_OCCON_OC32)
-#define OCCON_MODE16		(0)
+#define OCCON_OFF           (0)
+#define OCCON_IDLE_STOP     (1 << _BN_OCCON_SIDL)
+#define OCCON_IDLE_RUN      (0)
+#define OCCON_MODE32        (1 << _BN_OCCON_OC32)
+#define OCCON_MODE16        (0)
 #ifndef OCCON_OCFLT
-#define	OCCON_OCFLT			(1 << _BN_OCCON_OCFLT)
+#define OCCON_OCFLT         (1 << _BN_OCCON_OCFLT)
 #endif
-#define	OCCON_SRC_TIMER3	(1 << _BN_OCCON_OCTSEL)
-#define	OCCON_SRC_TIMER2	(0)
+#define OCCON_SRC_TIMER3    (1 << _BN_OCCON_OCTSEL)
+#define OCCON_SRC_TIMER2    (0)
 
-#define OCCON_PWM_FAULT_ENABLE		(7 << _BN_OCCON_OCM)
-#define	OCCON_PWM_FAULT_DISABLE		(6 << _BN_OCCON_OCM)
-#define	OCCON_PULSE_CONTINUOUS		(5 << _BN_OCCON_OCM)
-#define	OCCON_PULSE_SINGLE			(4 << _BN_OCCON_OCM)
-#define	OCCON_PULSE_TOGGLE			(3 << _BN_OCCON_OCM)
-#define	OCCON_FALLING_EDGE			(2 << _BN_OCCON_OCM)
-#define	OCCON_RISING_EDGE			(1 << _BN_OCCON_OCM)
-#define OCCON_MODE_OFF				(0 << _BN_OCCON_OCM)
+#define OCCON_PWM_FAULT_ENABLE      (7 << _BN_OCCON_OCM)
+#define OCCON_PWM_FAULT_DISABLE     (6 << _BN_OCCON_OCM)
+#define OCCON_PULSE_CONTINUOUS      (5 << _BN_OCCON_OCM)
+#define OCCON_PULSE_SINGLE          (4 << _BN_OCCON_OCM)
+#define OCCON_PULSE_TOGGLE          (3 << _BN_OCCON_OCM)
+#define OCCON_FALLING_EDGE          (2 << _BN_OCCON_OCM)
+#define OCCON_RISING_EDGE           (1 << _BN_OCCON_OCM)
+#define OCCON_MODE_OFF              (0 << _BN_OCCON_OCM)
 
 /* This structure defines the registers for a PIC32 A/D converter
 */
 typedef struct {
-	volatile p32_regset adxCon1;
-	volatile p32_regset adxCon2;
-	volatile p32_regset adxCon3;
-	volatile p32_regset adxChs;
-	volatile p32_regset adxPcfg;
-	volatile p32_regset adxCssl;
-	volatile p32_regbuf	adxBuf0;
-	volatile p32_regbuf	adxBuf1;
-	volatile p32_regbuf	adxBuf2;
-	volatile p32_regbuf	adxBuf3;
-	volatile p32_regbuf	adxBuf4;
-	volatile p32_regbuf	adxBuf5;
-	volatile p32_regbuf	adxBuf6;
-	volatile p32_regbuf	adxBuf7;
-	volatile p32_regbuf	adxBuf8;
-	volatile p32_regbuf	adxBuf9;
-	volatile p32_regbuf	adxBufA;
-	volatile p32_regbuf	adxBufB;
-	volatile p32_regbuf	adxBufC;
-	volatile p32_regbuf	adxBufD;
-	volatile p32_regbuf	adxBufE;
-	volatile p32_regbuf	adxBufF;
+    volatile p32_regset adxCon1;
+    volatile p32_regset adxCon2;
+    volatile p32_regset adxCon3;
+    volatile p32_regset adxChs;
+    volatile p32_regset adxPcfg;
+    volatile p32_regset adxCssl;
+    volatile p32_regbuf adxBuf0;
+    volatile p32_regbuf adxBuf1;
+    volatile p32_regbuf adxBuf2;
+    volatile p32_regbuf adxBuf3;
+    volatile p32_regbuf adxBuf4;
+    volatile p32_regbuf adxBuf5;
+    volatile p32_regbuf adxBuf6;
+    volatile p32_regbuf adxBuf7;
+    volatile p32_regbuf adxBuf8;
+    volatile p32_regbuf adxBuf9;
+    volatile p32_regbuf adxBufA;
+    volatile p32_regbuf adxBufB;
+    volatile p32_regbuf adxBufC;
+    volatile p32_regbuf adxBufD;
+    volatile p32_regbuf adxBufE;
+    volatile p32_regbuf adxBufF;
 } p32_adc;
 
 /* This structure defines the change notice/pull-up enable registers.
 */
 typedef struct {
-	volatile p32_regset cnCon;
-	volatile p32_regset cnEn;
-	volatile p32_regset cnPue;
+    volatile p32_regset cnCon;
+    volatile p32_regset cnEn;
+    volatile p32_regset cnPue;
 } p32_cn;
 
 /* This structure defines the registers for the PIC32 parallel master port.
 */
 typedef struct {
-	volatile p32_regset pmpCon;
-	volatile p32_regset pmpMode;
-	volatile p32_regset pmpAddr;
-	volatile p32_regset	pmpDout;
-	volatile p32_regset pmpDin;
-	volatile p32_regset	pmpAen;
-	volatile p32_regset pmpStat;
+    volatile p32_regset pmpCon;
+    volatile p32_regset pmpMode;
+    volatile p32_regset pmpAddr;
+    volatile p32_regset pmpDout;
+    volatile p32_regset pmpDin;
+    volatile p32_regset pmpAen;
+    volatile p32_regset pmpStat;
 } p32_pmp;
 
 
 /* ------------------------------------------------------------ */
-/*			Peripheral Pin Select Output Declarations			*/
+/*          Peripheral Pin Select Output Declarations           */
 /* ------------------------------------------------------------ */
 
 /* Currently, PPS is only supported in PIC32MX1xx/PIC32MX2xx/PIC32MX47X devices.
@@ -823,19 +852,19 @@ typedef uint32_t p32_ppsin;
 ** The set values associated with the input/output functions and the
 ** input/output pins are used for error checking in the mapping functions.
 */
-#define	_PPS_SET_A	0x0100
-#define _PPS_SET_B	0x0200
-#define	_PPS_SET_C	0x0400
-#define	_PPS_SET_D	0x0800
+#define _PPS_SET_A  0x0100
+#define _PPS_SET_B  0x0200
+#define _PPS_SET_C  0x0400
+#define _PPS_SET_D  0x0800
 
 /* Data type for PPS output select register.
 */
 typedef uint32_t p32_ppsout;
 
 #define _PPS_INPUT_BIT  (1 << 15)
-#define	PPS_OUT_MASK	0x000F
-#define	PPS_IN_MASK		0x00FF
-#define	NUM_PPS_IN		45          // This must be set to the highest PPS_IN_xxx value
+#define PPS_OUT_MASK    0x000F
+#define PPS_IN_MASK     0x00FF
+#define NUM_PPS_IN      45          // This must be set to the highest PPS_IN_xxx value
 #define NUM_PPS_OUT     7           // This must be set to the highest PPS_OUT_xxx value
 
 /* This enum specifies all of the possible input and output peripherals you can
@@ -851,27 +880,27 @@ typedef enum {
 ** are divided into four sets. Some peripheral functions are duplicated in more
 ** than one set. In this case they have the same select value in each set.
 */
-    PPS_OUT_GPIO	= (0 + (_PPS_SET_A|_PPS_SET_B|_PPS_SET_C|_PPS_SET_D)),
+    PPS_OUT_GPIO    = (0 + (_PPS_SET_A|_PPS_SET_B|_PPS_SET_C|_PPS_SET_D)),
 
-    PPS_OUT_U1TX	= (1 + _PPS_SET_A),
-    PPS_OUT_U2RTS	= (2 + _PPS_SET_A),
-    PPS_OUT_SS1		= (3 + _PPS_SET_A),
-    PPS_OUT_OC1		= (5 + _PPS_SET_A),
-    PPS_OUT_C2OUT	= (7 + _PPS_SET_A),
+    PPS_OUT_U1TX    = (1 + _PPS_SET_A),
+    PPS_OUT_U2RTS   = (2 + _PPS_SET_A),
+    PPS_OUT_SS1     = (3 + _PPS_SET_A),
+    PPS_OUT_OC1     = (5 + _PPS_SET_A),
+    PPS_OUT_C2OUT   = (7 + _PPS_SET_A),
 
-    PPS_OUT_SDO1	= (3 + (_PPS_SET_B | _PPS_SET_C)),
-    PPS_OUT_SDO2	= (4 + (_PPS_SET_B | _PPS_SET_C)),
-    PPS_OUT_OC2		= (5 + _PPS_SET_B),
+    PPS_OUT_SDO1    = (3 + (_PPS_SET_B | _PPS_SET_C)),
+    PPS_OUT_SDO2    = (4 + (_PPS_SET_B | _PPS_SET_C)),
+    PPS_OUT_OC2     = (5 + _PPS_SET_B),
 
-    PPS_OUT_OC4		= (5 + _PPS_SET_C),
-    PPS_OUT_OC5		= (6 + _PPS_SET_C),
-    PPS_OUT_REFCLKO	= (7 + _PPS_SET_C),
+    PPS_OUT_OC4     = (5 + _PPS_SET_C),
+    PPS_OUT_OC5     = (6 + _PPS_SET_C),
+    PPS_OUT_REFCLKO = (7 + _PPS_SET_C),
 
-    PPS_OUT_U1RTS	= (1 + _PPS_SET_D),
-    PPS_OUT_U2TX	= (2 + _PPS_SET_D),
-    PPS_OUT_SS2		= (4 + _PPS_SET_D),
-    PPS_OUT_OC3		= (5 + _PPS_SET_D),
-    PPS_OUT_C1OUT	= (7 + _PPS_SET_D),
+    PPS_OUT_U1RTS   = (1 + _PPS_SET_D),
+    PPS_OUT_U2TX    = (2 + _PPS_SET_D),
+    PPS_OUT_SS2     = (4 + _PPS_SET_D),
+    PPS_OUT_OC3     = (5 + _PPS_SET_D),
+    PPS_OUT_C1OUT   = (7 + _PPS_SET_D),
 
 /* The following symbols define the input functions that are mappable
 ** using PPS. These are used as an index to the input selection mapping
@@ -881,30 +910,30 @@ typedef enum {
 ** this mapping will have to be changed to be done through a table.
 */
 
-    PPS_IN_INT1		= (0  + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_INT2		= (1  + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_INT3		= (2  + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_INT4		= (3  + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_T2CK		= (5  + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_T3CK		= (6  + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_T4CK		= (7  + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_T5CK		= (8  + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_IC1		= (9  + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_IC2		= (10 + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_IC3		= (11 + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_IC4		= (12 + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_IC5		= (13 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_OCFA		= (17 + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_OCFB		= (18 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_U1RX		= (19 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_U1CTS	= (20 + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_U2RX		= (21 + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_U2CTS	= (22 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_SDI1		= (32 + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_SS1		= (33 + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_SDI2		= (35 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_SS2		= (36 + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_REFCLKI	= (45 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_INT1     = (0  + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_INT2     = (1  + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_INT3     = (2  + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_INT4     = (3  + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_T2CK     = (5  + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_T3CK     = (6  + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_T4CK     = (7  + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_T5CK     = (8  + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_IC1      = (9  + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_IC2      = (10 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_IC3      = (11 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_IC4      = (12 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_IC5      = (13 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_OCFA     = (17 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_OCFB     = (18 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_U1RX     = (19 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_U1CTS    = (20 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_U2RX     = (21 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_U2CTS    = (22 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_SDI1     = (32 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_SS1      = (33 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_SDI2     = (35 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_SS2      = (36 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_REFCLKI  = (45 + _PPS_SET_A + _PPS_INPUT_BIT),
 
 } ppsFunctionType;
 
@@ -919,83 +948,83 @@ typedef uint32_t p32_ppsin;
 ** into four disjoint sets. Set membership is defined as part of the value to
 ** allow error checking when the pins are being mapped.
 */
-#define	_PPS_RPA0		(0 + _PPS_SET_A)
-#define	_PPS_RPB3		(1 + _PPS_SET_A)
-#define	_PPS_RPB4		(2 + _PPS_SET_A)
-#define	_PPS_RPB15		(3 + _PPS_SET_A)
-#define	_PPS_RPB7		(4 + _PPS_SET_A)
-#define	_PPS_RPC7		(5 + _PPS_SET_A)
-#define	_PPS_RPC0		(6 + _PPS_SET_A)
-#define	_PPS_RPC5		(7 + _PPS_SET_A)
+#define _PPS_RPA0       (0 + _PPS_SET_A)
+#define _PPS_RPB3       (1 + _PPS_SET_A)
+#define _PPS_RPB4       (2 + _PPS_SET_A)
+#define _PPS_RPB15      (3 + _PPS_SET_A)
+#define _PPS_RPB7       (4 + _PPS_SET_A)
+#define _PPS_RPC7       (5 + _PPS_SET_A)
+#define _PPS_RPC0       (6 + _PPS_SET_A)
+#define _PPS_RPC5       (7 + _PPS_SET_A)
 
-#define	_PPS_RPA1		(0 + _PPS_SET_B)
-#define	_PPS_RPB5		(1 + _PPS_SET_B)
-#define	_PPS_RPB1		(2 + _PPS_SET_B)
-#define	_PPS_RPB11		(3 + _PPS_SET_B)
-#define	_PPS_RPB8		(4 + _PPS_SET_B)
-#define	_PPS_RPA8		(5 + _PPS_SET_B)
-#define	_PPS_RPC8		(6 + _PPS_SET_B)
-#define	_PPS_RPA9		(7 + _PPS_SET_B)
+#define _PPS_RPA1       (0 + _PPS_SET_B)
+#define _PPS_RPB5       (1 + _PPS_SET_B)
+#define _PPS_RPB1       (2 + _PPS_SET_B)
+#define _PPS_RPB11      (3 + _PPS_SET_B)
+#define _PPS_RPB8       (4 + _PPS_SET_B)
+#define _PPS_RPA8       (5 + _PPS_SET_B)
+#define _PPS_RPC8       (6 + _PPS_SET_B)
+#define _PPS_RPA9       (7 + _PPS_SET_B)
 
-#define	_PPS_RPA2		(0 + _PPS_SET_C)
-#define	_PPS_RPB6		(1 + _PPS_SET_C)
-#define	_PPS_RPA4		(2 + _PPS_SET_C)
-#define	_PPS_RPB13		(3 + _PPS_SET_C)
-#define	_PPS_RPB2		(4 + _PPS_SET_C)
-#define	_PPS_RPC6		(5 + _PPS_SET_C)
-#define	_PPS_RPC1		(6 + _PPS_SET_C)
-#define	_PPS_RPC3		(7 + _PPS_SET_C)
+#define _PPS_RPA2       (0 + _PPS_SET_C)
+#define _PPS_RPB6       (1 + _PPS_SET_C)
+#define _PPS_RPA4       (2 + _PPS_SET_C)
+#define _PPS_RPB13      (3 + _PPS_SET_C)
+#define _PPS_RPB2       (4 + _PPS_SET_C)
+#define _PPS_RPC6       (5 + _PPS_SET_C)
+#define _PPS_RPC1       (6 + _PPS_SET_C)
+#define _PPS_RPC3       (7 + _PPS_SET_C)
 
-#define	_PPS_RPA3		(0 + _PPS_SET_D)
-#define	_PPS_RPB14		(1 + _PPS_SET_D)
-#define	_PPS_RPB0		(2 + _PPS_SET_D)
-#define	_PPS_RPB10		(3 + _PPS_SET_D)
-#define	_PPS_RPB9		(4 + _PPS_SET_D)
-#define	_PPS_RPC9		(5 + _PPS_SET_D)
-#define	_PPS_RPC2		(6 + _PPS_SET_D)
-#define	_PPS_RPC4		(7 + _PPS_SET_D)
+#define _PPS_RPA3       (0 + _PPS_SET_D)
+#define _PPS_RPB14      (1 + _PPS_SET_D)
+#define _PPS_RPB0       (2 + _PPS_SET_D)
+#define _PPS_RPB10      (3 + _PPS_SET_D)
+#define _PPS_RPB9       (4 + _PPS_SET_D)
+#define _PPS_RPC9       (5 + _PPS_SET_D)
+#define _PPS_RPC2       (6 + _PPS_SET_D)
+#define _PPS_RPC4       (7 + _PPS_SET_D)
 
 /* These symbols define the indices of the output pin mapping
 ** registers.
 */
-#define	_PPS_RPA0R		0
-#define	_PPS_RPA1R		1
-#define	_PPS_RPA2R		2
-#define	_PPS_RPA3R		3
-#define	_PPS_RPA4R		4
-#define _PPS_RPA8R		8
-#define	_PPS_RPA9R		9
+#define _PPS_RPA0R      0
+#define _PPS_RPA1R      1
+#define _PPS_RPA2R      2
+#define _PPS_RPA3R      3
+#define _PPS_RPA4R      4
+#define _PPS_RPA8R      8
+#define _PPS_RPA9R      9
 
-#define	_PPS_RPB0R		11
-#define	_PPS_RPB1R		12
-#define	_PPS_RPB2R		13
-#define	_PPS_RPB3R		14
-#define	_PPS_RPB4R		15
-#define	_PPS_RPB5R		16
+#define _PPS_RPB0R      11
+#define _PPS_RPB1R      12
+#define _PPS_RPB2R      13
+#define _PPS_RPB3R      14
+#define _PPS_RPB4R      15
+#define _PPS_RPB5R      16
 #if defined(__PIC32MX1XX__)
-#define	_PPS_RPB6R		17
+#define _PPS_RPB6R      17
 #else
-#define	_PPS_RPB6R		NOT_PPS_PIN
+#define _PPS_RPB6R      NOT_PPS_PIN
 #endif
-#define	_PPS_RPB7R		18
-#define	_PPS_RPB8R		19
-#define	_PPS_RPB9R		20
-#define	_PPS_RPB10R		21
-#define	_PPS_RPB11R		22
-#define	_PPS_RPB13R		24
-#define	_PPS_RPB14R		25
-#define	_PPS_RPB15R		26
+#define _PPS_RPB7R      18
+#define _PPS_RPB8R      19
+#define _PPS_RPB9R      20
+#define _PPS_RPB10R     21
+#define _PPS_RPB11R     22
+#define _PPS_RPB13R     24
+#define _PPS_RPB14R     25
+#define _PPS_RPB15R     26
 
-#define	_PPS_RPC0R		27
-#define	_PPS_RPC1R		28
-#define	_PPS_RPC2R		29
-#define	_PPS_RPC3R		30
-#define	_PPS_RPC4R		31
-#define	_PPS_RPC5R		32
-#define	_PPS_RPC6R		33
-#define	_PPS_RPC7R		34
-#define	_PPS_RPC8R		35
-#define	_PPS_RPC9R		36
+#define _PPS_RPC0R      27
+#define _PPS_RPC1R      28
+#define _PPS_RPC2R      29
+#define _PPS_RPC3R      30
+#define _PPS_RPC4R      31
+#define _PPS_RPC5R      32
+#define _PPS_RPC6R      33
+#define _PPS_RPC7R      34
+#define _PPS_RPC8R      35
+#define _PPS_RPC9R      36
 
 #elif defined(__PIC32MZXX__)
 
@@ -1008,19 +1037,19 @@ typedef uint32_t p32_ppsin;
 ** The set values associated with the input/output functions and the
 ** input/output pins are used for error checking in the mapping functions.
 */
-#define	_PPS_SET_A	0x0100
-#define _PPS_SET_B	0x0200
-#define	_PPS_SET_C	0x0400
-#define	_PPS_SET_D	0x0800
+#define _PPS_SET_A  0x0100
+#define _PPS_SET_B  0x0200
+#define _PPS_SET_C  0x0400
+#define _PPS_SET_D  0x0800
 
 /* Data type for PPS output select register.
 */
 typedef uint32_t p32_ppsout;
 
 #define _PPS_INPUT_BIT  (1 << 15)
-#define	PPS_OUT_MASK	0x000F
-#define	PPS_IN_MASK		0x00FF
-#define	NUM_PPS_IN		60          // This must be set to the highest PPS_IN_xxx value
+#define PPS_OUT_MASK    0x000F
+#define PPS_IN_MASK     0x00FF
+#define NUM_PPS_IN      60          // This must be set to the highest PPS_IN_xxx value
 #define NUM_PPS_OUT     15           // This must be set to the highest PPS_OUT_xxx value
 
 /* This enum specifies all of the possible input and output peripherals you can
@@ -1103,57 +1132,57 @@ typedef enum {
     // all other bits are for validation of the appropriate
     // PPS set.
 
-    PPS_IN_INT1		= (0  + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_INT2		= (1  + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_INT3		= (2  + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_INT4		= (3  + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_T2CK		= (5  + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_T3CK		= (6  + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_T4CK		= (7  + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_T5CK		= (8  + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_T6CK		= (9  + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_T7CK		= (10  + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_T8CK		= (11  + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_T9CK		= (12  + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_IC1		= (13  + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_IC2		= (14 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_IC3		= (15 + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_IC4		= (16 + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_IC5		= (17 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_IC6		= (18 + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_IC7		= (19 + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_IC8		= (20 + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_IC9		= (21 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_OCFA		= (23 + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_U1RX		= (25 + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_U1CTS	= (26 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_U2RX		= (27 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_U2CTS	= (28 + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_U3RX		= (29 + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_U3CTS	= (30 + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_U4RX		= (31 + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_U4CTS	= (32 + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_U5RX		= (33 + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_U5CTS	= (34 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_U6RX		= (35 + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_U6CTS	= (36 + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_SDI1		= (38 + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_SS1		= (39 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_SDI2		= (41 + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_SS2		= (42 + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_SDI3		= (44 + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_SS3		= (45 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_SDI4		= (47 + _PPS_SET_B + _PPS_INPUT_BIT),
-    PPS_IN_SS4		= (48 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_SDI5		= (50 + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_SS5		= (51 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_SDI6		= (53 + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_SS6		= (54 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_INT1     = (0  + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_INT2     = (1  + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_INT3     = (2  + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_INT4     = (3  + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_T2CK     = (5  + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_T3CK     = (6  + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_T4CK     = (7  + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_T5CK     = (8  + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_T6CK     = (9  + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_T7CK     = (10  + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_T8CK     = (11  + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_T9CK     = (12  + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_IC1      = (13  + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_IC2      = (14 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_IC3      = (15 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_IC4      = (16 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_IC5      = (17 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_IC6      = (18 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_IC7      = (19 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_IC8      = (20 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_IC9      = (21 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_OCFA     = (23 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_U1RX     = (25 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_U1CTS    = (26 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_U2RX     = (27 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_U2CTS    = (28 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_U3RX     = (29 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_U3CTS    = (30 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_U4RX     = (31 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_U4CTS    = (32 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_U5RX     = (33 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_U5CTS    = (34 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_U6RX     = (35 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_U6CTS    = (36 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_SDI1     = (38 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_SS1      = (39 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_SDI2     = (41 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_SS2      = (42 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_SDI3     = (44 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_SS3      = (45 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_SDI4     = (47 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_SS4      = (48 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_SDI5     = (50 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_SS5      = (51 + _PPS_SET_C + _PPS_INPUT_BIT),
+    PPS_IN_SDI6     = (53 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_SS6      = (54 + _PPS_SET_A + _PPS_INPUT_BIT),
     PPS_IN_C1RX         = (55 + _PPS_SET_B + _PPS_INPUT_BIT),
     PPS_IN_C2RX         = (56 + _PPS_SET_C + _PPS_INPUT_BIT),
-    PPS_IN_REFCLKI1	= (57 + _PPS_SET_A + _PPS_INPUT_BIT),
-    PPS_IN_REFCLKI3	= (59 + _PPS_SET_D + _PPS_INPUT_BIT),
-    PPS_IN_REFCLKI4	= (60 + _PPS_SET_B + _PPS_INPUT_BIT),
+    PPS_IN_REFCLKI1 = (57 + _PPS_SET_A + _PPS_INPUT_BIT),
+    PPS_IN_REFCLKI3 = (59 + _PPS_SET_D + _PPS_INPUT_BIT),
+    PPS_IN_REFCLKI4 = (60 + _PPS_SET_B + _PPS_INPUT_BIT),
 
 } ppsFunctionType;
 
@@ -1166,107 +1195,107 @@ typedef uint32_t p32_ppsin;
 ** registers.
 */
 
-#define	_PPS_RPB0R		0
-#define	_PPS_RPB1R		1
-#define	_PPS_RPB2R		2
-#define	_PPS_RPB3R		3
-// #define	_PPS_RPB4R		4
-#define	_PPS_RPB5R		5
-#define	_PPS_RPB6R		6
-#define	_PPS_RPB7R		7
-#define	_PPS_RPB8R		8
-#define	_PPS_RPB9R		9
-#define	_PPS_RPB10R		10
-// #define	_PPS_RPB11R		11
-// #define	_PPS_RPB12R		12
-// #define	_PPS_RPB13R		13
-#define	_PPS_RPB14R		14
-#define	_PPS_RPB15R		15
+#define _PPS_RPB0R      0
+#define _PPS_RPB1R      1
+#define _PPS_RPB2R      2
+#define _PPS_RPB3R      3
+// #define  _PPS_RPB4R      4
+#define _PPS_RPB5R      5
+#define _PPS_RPB6R      6
+#define _PPS_RPB7R      7
+#define _PPS_RPB8R      8
+#define _PPS_RPB9R      9
+#define _PPS_RPB10R     10
+// #define  _PPS_RPB11R     11
+// #define  _PPS_RPB12R     12
+// #define  _PPS_RPB13R     13
+#define _PPS_RPB14R     14
+#define _PPS_RPB15R     15
 
-//#define	_PPS_RPC0R		16
-#define	_PPS_RPC1R		17
-#define	_PPS_RPC2R		18
-#define	_PPS_RPC3R		19
-#define	_PPS_RPC4R		20
-//#define	_PPS_RPC5R		21
-//#define	_PPS_RPC6R		22
-//#define	_PPS_RPC7R		23
-//#define	_PPS_RPC8R		24
-//#define	_PPS_RPC9R		25
-//#define	_PPS_RPC10R		26
-//#define	_PPS_RPC11R		27
-//#define	_PPS_RPC12R		28
-#define	_PPS_RPC13R		29
-#define	_PPS_RPC14R		30
-//#define	_PPS_RPC15R		31
+//#define   _PPS_RPC0R      16
+#define _PPS_RPC1R      17
+#define _PPS_RPC2R      18
+#define _PPS_RPC3R      19
+#define _PPS_RPC4R      20
+//#define   _PPS_RPC5R      21
+//#define   _PPS_RPC6R      22
+//#define   _PPS_RPC7R      23
+//#define   _PPS_RPC8R      24
+//#define   _PPS_RPC9R      25
+//#define   _PPS_RPC10R     26
+//#define   _PPS_RPC11R     27
+//#define   _PPS_RPC12R     28
+#define _PPS_RPC13R     29
+#define _PPS_RPC14R     30
+//#define   _PPS_RPC15R     31
 
-#define	_PPS_RPD0R		32
-#define	_PPS_RPD1R		33
-#define	_PPS_RPD2R		34
-#define	_PPS_RPD3R		35
-#define	_PPS_RPD4R		36
-#define	_PPS_RPD5R		37
-#define	_PPS_RPD6R		38
-#define	_PPS_RPD7R		39
-//#define	_PPS_RPD8R		40
-#define	_PPS_RPD9R		41
-#define	_PPS_RPD10R		42
-#define	_PPS_RPD11R		43
-#define	_PPS_RPD12R		44
-//#define	_PPS_RPD13R		45
-#define	_PPS_RPD14R		46
-#define	_PPS_RPD15R		47
+#define _PPS_RPD0R      32
+#define _PPS_RPD1R      33
+#define _PPS_RPD2R      34
+#define _PPS_RPD3R      35
+#define _PPS_RPD4R      36
+#define _PPS_RPD5R      37
+#define _PPS_RPD6R      38
+#define _PPS_RPD7R      39
+//#define   _PPS_RPD8R      40
+#define _PPS_RPD9R      41
+#define _PPS_RPD10R     42
+#define _PPS_RPD11R     43
+#define _PPS_RPD12R     44
+//#define   _PPS_RPD13R     45
+#define _PPS_RPD14R     46
+#define _PPS_RPD15R     47
 
-//#define	_PPS_RPE0R		48
-//#define	_PPS_RPE1R		49
-//#define	_PPS_RPE2R		50
-#define	_PPS_RPE3R		51
-//#define	_PPS_RPE4R		52
-#define	_PPS_RPE5R		53
-//#define	_PPS_RPE6R		54
-//#define	_PPS_RPE7R		55
-#define	_PPS_RPE8R		56
-#define	_PPS_RPE9R		57
-//#define	_PPS_RPE10R		58
-//#define	_PPS_RPE11R		59
-//#define	_PPS_RPE12R		60
-//#define	_PPS_RPE13R		61
-//#define	_PPS_RPE14R		62
-//#define	_PPS_RPE15R		63
+//#define   _PPS_RPE0R      48
+//#define   _PPS_RPE1R      49
+//#define   _PPS_RPE2R      50
+#define _PPS_RPE3R      51
+//#define   _PPS_RPE4R      52
+#define _PPS_RPE5R      53
+//#define   _PPS_RPE6R      54
+//#define   _PPS_RPE7R      55
+#define _PPS_RPE8R      56
+#define _PPS_RPE9R      57
+//#define   _PPS_RPE10R     58
+//#define   _PPS_RPE11R     59
+//#define   _PPS_RPE12R     60
+//#define   _PPS_RPE13R     61
+//#define   _PPS_RPE14R     62
+//#define   _PPS_RPE15R     63
 
-#define	_PPS_RPF0R		64
-#define	_PPS_RPF1R		65
-#define	_PPS_RPF2R		66
-#define	_PPS_RPF3R		67
-#define	_PPS_RPF4R		68
-#define	_PPS_RPF5R		69
-//#define	_PPS_RPF6R		70
-//#define	_PPS_RPF7R		71
-#define	_PPS_RPF8R		72
-//#define	_PPS_RPF9R		73
-//#define	_PPS_RPF10R		74
-//#define	_PPS_RPF11R		75
-#define	_PPS_RPF12R		76
-#define	_PPS_RPF13R		77
-//#define	_PPS_RPF14R		78
-//#define	_PPS_RPF15R		79
+#define _PPS_RPF0R      64
+#define _PPS_RPF1R      65
+#define _PPS_RPF2R      66
+#define _PPS_RPF3R      67
+#define _PPS_RPF4R      68
+#define _PPS_RPF5R      69
+//#define   _PPS_RPF6R      70
+//#define   _PPS_RPF7R      71
+#define _PPS_RPF8R      72
+//#define   _PPS_RPF9R      73
+//#define   _PPS_RPF10R     74
+//#define   _PPS_RPF11R     75
+#define _PPS_RPF12R     76
+#define _PPS_RPF13R     77
+//#define   _PPS_RPF14R     78
+//#define   _PPS_RPF15R     79
 
-#define	_PPS_RPG0R		80
-#define	_PPS_RPG1R		81
-//#define	_PPS_RPG2R		82
-//#define	_PPS_RPG3R		83
-//#define	_PPS_RPG4R		84
-//#define	_PPS_RPG5R		85
-#define	_PPS_RPG6R		86
-#define	_PPS_RPG7R		87
-#define	_PPS_RPG8R		88
-#define	_PPS_RPG9R		89
-//#define	_PPS_RPG10R		90
-//#define	_PPS_RPG11R		91
-//#define	_PPS_RPG12R		92
-//#define	_PPS_RPG13R		93
-//#define	_PPS_RPG14R		94
-//#define	_PPS_RPG15R		95
+#define _PPS_RPG0R      80
+#define _PPS_RPG1R      81
+//#define   _PPS_RPG2R      82
+//#define   _PPS_RPG3R      83
+//#define   _PPS_RPG4R      84
+//#define   _PPS_RPG5R      85
+#define _PPS_RPG6R      86
+#define _PPS_RPG7R      87
+#define _PPS_RPG8R      88
+#define _PPS_RPG9R      89
+//#define   _PPS_RPG10R     90
+//#define   _PPS_RPG11R     91
+//#define   _PPS_RPG12R     92
+//#define   _PPS_RPG13R     93
+//#define   _PPS_RPG14R     94
+//#define   _PPS_RPG15R     95
 
 
 #else
@@ -1274,110 +1303,110 @@ typedef uint32_t p32_ppsin;
 /* These symbols define the indices of the output pin mapping
 ** registers.
 */
-#define	_PPS_RPA14R		0
-#define	_PPS_RPA15R		1
+#define _PPS_RPA14R     0
+#define _PPS_RPA15R     1
 
-#define	_PPS_RPB0R		2
-#define	_PPS_RPB1R		3
-#define	_PPS_RPB2R		4
-#define	_PPS_RPB3R		5
-// #define	_PPS_RPB4R		6
-#define	_PPS_RPB5R		7
-#define	_PPS_RPB6R		8
-#define	_PPS_RPB7R		9
-#define	_PPS_RPB8R		10
-#define	_PPS_RPB9R		11
-#define	_PPS_RPB10R		12
-// #define	_PPS_RPB11R		13
-// #define	_PPS_RPB12R		14
-// #define	_PPS_RPB13R		15
-#define	_PPS_RPB14R		16
-#define	_PPS_RPB15R		17
+#define _PPS_RPB0R      2
+#define _PPS_RPB1R      3
+#define _PPS_RPB2R      4
+#define _PPS_RPB3R      5
+// #define  _PPS_RPB4R      6
+#define _PPS_RPB5R      7
+#define _PPS_RPB6R      8
+#define _PPS_RPB7R      9
+#define _PPS_RPB8R      10
+#define _PPS_RPB9R      11
+#define _PPS_RPB10R     12
+// #define  _PPS_RPB11R     13
+// #define  _PPS_RPB12R     14
+// #define  _PPS_RPB13R     15
+#define _PPS_RPB14R     16
+#define _PPS_RPB15R     17
 
-//#define	_PPS_RPC0R		18
-#define	_PPS_RPC1R		19
-#define	_PPS_RPC2R		20
-#define	_PPS_RPC3R		21
-#define	_PPS_RPC4R		22
-//#define	_PPS_RPC5R		23
-//#define	_PPS_RPC6R		24
-//#define	_PPS_RPC7R		25
-//#define	_PPS_RPC8R		26
-//#define	_PPS_RPC9R		27
-//#define	_PPS_RPC10R		28
-//#define	_PPS_RPC11R		29
-//#define	_PPS_RPC12R		30
-#define	_PPS_RPC13R		31
-#define	_PPS_RPC14R		32
-//#define	_PPS_RPC15R		33
+//#define   _PPS_RPC0R      18
+#define _PPS_RPC1R      19
+#define _PPS_RPC2R      20
+#define _PPS_RPC3R      21
+#define _PPS_RPC4R      22
+//#define   _PPS_RPC5R      23
+//#define   _PPS_RPC6R      24
+//#define   _PPS_RPC7R      25
+//#define   _PPS_RPC8R      26
+//#define   _PPS_RPC9R      27
+//#define   _PPS_RPC10R     28
+//#define   _PPS_RPC11R     29
+//#define   _PPS_RPC12R     30
+#define _PPS_RPC13R     31
+#define _PPS_RPC14R     32
+//#define   _PPS_RPC15R     33
 
-#define	_PPS_RPD0R		34
-#define	_PPS_RPD1R		35
-#define	_PPS_RPD2R		36
-#define	_PPS_RPD3R		37
-#define	_PPS_RPD4R		38
-#define	_PPS_RPD5R		39
-#define	_PPS_RPD6R		40
-#define	_PPS_RPD7R		41
-//#define	_PPS_RPD8R		42
-#define	_PPS_RPD9R		43
-#define	_PPS_RPD10R		44
-#define	_PPS_RPD11R		45
-#define	_PPS_RPD12R		46
-//#define	_PPS_RPD13R		47
-#define	_PPS_RPD14R		48
-#define	_PPS_RPD15R		49
+#define _PPS_RPD0R      34
+#define _PPS_RPD1R      35
+#define _PPS_RPD2R      36
+#define _PPS_RPD3R      37
+#define _PPS_RPD4R      38
+#define _PPS_RPD5R      39
+#define _PPS_RPD6R      40
+#define _PPS_RPD7R      41
+//#define   _PPS_RPD8R      42
+#define _PPS_RPD9R      43
+#define _PPS_RPD10R     44
+#define _PPS_RPD11R     45
+#define _PPS_RPD12R     46
+//#define   _PPS_RPD13R     47
+#define _PPS_RPD14R     48
+#define _PPS_RPD15R     49
 
-//#define	_PPS_RPE0R		50
-//#define	_PPS_RPE1R		51
-//#define	_PPS_RPE2R		52
-#define	_PPS_RPE3R		53
-//#define	_PPS_RPE4R		54
-#define	_PPS_RPE5R		55
-//#define	_PPS_RPE6R		56
-//#define	_PPS_RPE7R		57
-#define	_PPS_RPE8R		58
-#define	_PPS_RPE9R		59
-//#define	_PPS_RPE10R		60
-//#define	_PPS_RPE11R		61
-//#define	_PPS_RPE12R		62
-//#define	_PPS_RPE13R		63
-//#define	_PPS_RPE14R		64
-//#define	_PPS_RPE15R		65
+//#define   _PPS_RPE0R      50
+//#define   _PPS_RPE1R      51
+//#define   _PPS_RPE2R      52
+#define _PPS_RPE3R      53
+//#define   _PPS_RPE4R      54
+#define _PPS_RPE5R      55
+//#define   _PPS_RPE6R      56
+//#define   _PPS_RPE7R      57
+#define _PPS_RPE8R      58
+#define _PPS_RPE9R      59
+//#define   _PPS_RPE10R     60
+//#define   _PPS_RPE11R     61
+//#define   _PPS_RPE12R     62
+//#define   _PPS_RPE13R     63
+//#define   _PPS_RPE14R     64
+//#define   _PPS_RPE15R     65
 
-#define	_PPS_RPF0R		66
-#define	_PPS_RPF1R		67
-#define	_PPS_RPF2R		68
-#define	_PPS_RPF3R		69
-#define	_PPS_RPF4R		70
-#define	_PPS_RPF5R		71
-//#define	_PPS_RPF6R		72
-//#define	_PPS_RPF7R		73
-#define	_PPS_RPF8R		74
-//#define	_PPS_RPF9R		74
-//#define	_PPS_RPF10R		76
-//#define	_PPS_RPF11R		77
-#define	_PPS_RPF12R		78
-#define	_PPS_RPF13R		79
-//#define	_PPS_RPF14R		80
-//#define	_PPS_RPF15R		81
+#define _PPS_RPF0R      66
+#define _PPS_RPF1R      67
+#define _PPS_RPF2R      68
+#define _PPS_RPF3R      69
+#define _PPS_RPF4R      70
+#define _PPS_RPF5R      71
+//#define   _PPS_RPF6R      72
+//#define   _PPS_RPF7R      73
+#define _PPS_RPF8R      74
+//#define   _PPS_RPF9R      74
+//#define   _PPS_RPF10R     76
+//#define   _PPS_RPF11R     77
+#define _PPS_RPF12R     78
+#define _PPS_RPF13R     79
+//#define   _PPS_RPF14R     80
+//#define   _PPS_RPF15R     81
 
-#define	_PPS_RPG0R		82
-#define	_PPS_RPG1R		83
-//#define	_PPS_RPG2R		84
-//#define	_PPS_RPG3R		85
-//#define	_PPS_RPG4R		86
-//#define	_PPS_RPG5R		87
-#define	_PPS_RPG6R		88
-#define	_PPS_RPG7R		89
-#define	_PPS_RPG8R		90
-#define	_PPS_RPG9R		91
-//#define	_PPS_RPG10R		92
-//#define	_PPS_RPG11R		93
-//#define	_PPS_RPG12R		94
-//#define	_PPS_RPG13R		95
-//#define	_PPS_RPG14R		96
-//#define	_PPS_RPG15R		97
+#define _PPS_RPG0R      82
+#define _PPS_RPG1R      83
+//#define   _PPS_RPG2R      84
+//#define   _PPS_RPG3R      85
+//#define   _PPS_RPG4R      86
+//#define   _PPS_RPG5R      87
+#define _PPS_RPG6R      88
+#define _PPS_RPG7R      89
+#define _PPS_RPG8R      90
+#define _PPS_RPG9R      91
+//#define   _PPS_RPG10R     92
+//#define   _PPS_RPG11R     93
+//#define   _PPS_RPG12R     94
+//#define   _PPS_RPG13R     95
+//#define   _PPS_RPG14R     96
+//#define   _PPS_RPG15R     97
 
 #endif
 
@@ -1387,78 +1416,78 @@ typedef uint32_t p32_ppsin;
 ** allow error checking when the pins are being mapped.
 */
 
-#define	_PPS_RPD2		(0 + _PPS_SET_A)
-#define	_PPS_RPG8		(1 + _PPS_SET_A)
-#define	_PPS_RPF4		(2 + _PPS_SET_A)
-#define	_PPS_RPD10		(3 + _PPS_SET_A)
-#define	_PPS_RPF1		(4 + _PPS_SET_A)
-#define	_PPS_RPB9		(5 + _PPS_SET_A)
-#define	_PPS_RPB10		(6 + _PPS_SET_A)
-#define	_PPS_RPC14		(7 + _PPS_SET_A)
-#define	_PPS_RPB5		(8 + _PPS_SET_A)
-//#define	_PPS_RPXX		(9 + _PPS_SET_A)
-#define	_PPS_RPC1		(10 + _PPS_SET_A)
-#define	_PPS_RPD14		(11 + _PPS_SET_A)
-#define	_PPS_RPG1		(12 + _PPS_SET_A)
-#define	_PPS_RPA14		(13 + _PPS_SET_A)
-#define	_PPS_RPD6		(14 + _PPS_SET_A)
-//#define	_PPS_RPXX		(15 + _PPS_SET_A)
+#define _PPS_RPD2       (0 + _PPS_SET_A)
+#define _PPS_RPG8       (1 + _PPS_SET_A)
+#define _PPS_RPF4       (2 + _PPS_SET_A)
+#define _PPS_RPD10      (3 + _PPS_SET_A)
+#define _PPS_RPF1       (4 + _PPS_SET_A)
+#define _PPS_RPB9       (5 + _PPS_SET_A)
+#define _PPS_RPB10      (6 + _PPS_SET_A)
+#define _PPS_RPC14      (7 + _PPS_SET_A)
+#define _PPS_RPB5       (8 + _PPS_SET_A)
+//#define   _PPS_RPXX       (9 + _PPS_SET_A)
+#define _PPS_RPC1       (10 + _PPS_SET_A)
+#define _PPS_RPD14      (11 + _PPS_SET_A)
+#define _PPS_RPG1       (12 + _PPS_SET_A)
+#define _PPS_RPA14      (13 + _PPS_SET_A)
+#define _PPS_RPD6       (14 + _PPS_SET_A)
+//#define   _PPS_RPXX       (15 + _PPS_SET_A)
 
-#define	_PPS_RPD3		(0 + _PPS_SET_B)
-#define	_PPS_RPG7		(1 + _PPS_SET_B)
-#define	_PPS_RPF5		(2 + _PPS_SET_B)
-#define	_PPS_RPD11		(3 + _PPS_SET_B)
-#define	_PPS_RPF0		(4 + _PPS_SET_B)
-#define	_PPS_RPB1		(5 + _PPS_SET_B)
-#define	_PPS_RPE5		(6 + _PPS_SET_B)
-#define	_PPS_RPC13		(7 + _PPS_SET_B)
-#define	_PPS_RPB3		(8 + _PPS_SET_B)
-//#define	_PPS_RPXX		(9 + _PPS_SET_B)
-#define	_PPS_RPC4		(10 + _PPS_SET_B)
-#define	_PPS_RPD15		(11 + _PPS_SET_B)
-#define	_PPS_RPG0		(12 + _PPS_SET_B)
-#define	_PPS_RPA15		(13 + _PPS_SET_B)
-#define	_PPS_RPD7		(14 + _PPS_SET_B)
-//#define	_PPS_RPXX		(15 + _PPS_SET_B)
+#define _PPS_RPD3       (0 + _PPS_SET_B)
+#define _PPS_RPG7       (1 + _PPS_SET_B)
+#define _PPS_RPF5       (2 + _PPS_SET_B)
+#define _PPS_RPD11      (3 + _PPS_SET_B)
+#define _PPS_RPF0       (4 + _PPS_SET_B)
+#define _PPS_RPB1       (5 + _PPS_SET_B)
+#define _PPS_RPE5       (6 + _PPS_SET_B)
+#define _PPS_RPC13      (7 + _PPS_SET_B)
+#define _PPS_RPB3       (8 + _PPS_SET_B)
+//#define   _PPS_RPXX       (9 + _PPS_SET_B)
+#define _PPS_RPC4       (10 + _PPS_SET_B)
+#define _PPS_RPD15      (11 + _PPS_SET_B)
+#define _PPS_RPG0       (12 + _PPS_SET_B)
+#define _PPS_RPA15      (13 + _PPS_SET_B)
+#define _PPS_RPD7       (14 + _PPS_SET_B)
+//#define   _PPS_RPXX       (15 + _PPS_SET_B)
 
-#define	_PPS_RPD9		(0 + _PPS_SET_C)
-#define	_PPS_RPG6		(1 + _PPS_SET_C)
-#define	_PPS_RPB8		(2 + _PPS_SET_C)
-#define	_PPS_RPB15		(3 + _PPS_SET_C)
-#define	_PPS_RPD4		(4 + _PPS_SET_C)
-#define	_PPS_RPB0		(5 + _PPS_SET_C)
-#define	_PPS_RPE3		(6 + _PPS_SET_C)
-#define	_PPS_RPB7		(7 + _PPS_SET_C)
-//#define	_PPS_RPXX		(8 + _PPS_SET_C)
-#define	_PPS_RPF12		(9 + _PPS_SET_C)
-#define	_PPS_RPD12		(10 + _PPS_SET_C)
-#define	_PPS_RPF8		(11 + _PPS_SET_C)
-#define	_PPS_RPC3		(12 + _PPS_SET_C)
-#define	_PPS_RPE9		(13 + _PPS_SET_C)
-//#define	_PPS_RPXX		(14 + _PPS_SET_C)
-//#define	_PPS_RPXX		(15 + _PPS_SET_C)
+#define _PPS_RPD9       (0 + _PPS_SET_C)
+#define _PPS_RPG6       (1 + _PPS_SET_C)
+#define _PPS_RPB8       (2 + _PPS_SET_C)
+#define _PPS_RPB15      (3 + _PPS_SET_C)
+#define _PPS_RPD4       (4 + _PPS_SET_C)
+#define _PPS_RPB0       (5 + _PPS_SET_C)
+#define _PPS_RPE3       (6 + _PPS_SET_C)
+#define _PPS_RPB7       (7 + _PPS_SET_C)
+//#define   _PPS_RPXX       (8 + _PPS_SET_C)
+#define _PPS_RPF12      (9 + _PPS_SET_C)
+#define _PPS_RPD12      (10 + _PPS_SET_C)
+#define _PPS_RPF8       (11 + _PPS_SET_C)
+#define _PPS_RPC3       (12 + _PPS_SET_C)
+#define _PPS_RPE9       (13 + _PPS_SET_C)
+//#define   _PPS_RPXX       (14 + _PPS_SET_C)
+//#define   _PPS_RPXX       (15 + _PPS_SET_C)
 
-#define	_PPS_RPD1		(0 + _PPS_SET_D)
-#define	_PPS_RPG9		(1 + _PPS_SET_D)
-#define	_PPS_RPB14		(2 + _PPS_SET_D)
-#define	_PPS_RPD0		(3 + _PPS_SET_D)
-//#define	_PPS_RPXX		(4 + _PPS_SET_D)
-#define	_PPS_RPB6		(5 + _PPS_SET_D)
-#define	_PPS_RPD5		(6 + _PPS_SET_D)
-#define	_PPS_RPB2		(7 + _PPS_SET_D)
-#define	_PPS_RPF3		(8 + _PPS_SET_D)
-#define	_PPS_RPF13		(9 + _PPS_SET_D)
-//#define	_PPS_RPXX		(10 + _PPS_SET_D)
-#define	_PPS_RPF2		(11 + _PPS_SET_D)
-#define	_PPS_RPC2		(12 + _PPS_SET_D)
-#define	_PPS_RPE8		(13 + _PPS_SET_D)
-//#define	_PPS_RPXX		(14 + _PPS_SET_D)
-//#define	_PPS_RPXX		(15 + _PPS_SET_D)
+#define _PPS_RPD1       (0 + _PPS_SET_D)
+#define _PPS_RPG9       (1 + _PPS_SET_D)
+#define _PPS_RPB14      (2 + _PPS_SET_D)
+#define _PPS_RPD0       (3 + _PPS_SET_D)
+//#define   _PPS_RPXX       (4 + _PPS_SET_D)
+#define _PPS_RPB6       (5 + _PPS_SET_D)
+#define _PPS_RPD5       (6 + _PPS_SET_D)
+#define _PPS_RPB2       (7 + _PPS_SET_D)
+#define _PPS_RPF3       (8 + _PPS_SET_D)
+#define _PPS_RPF13      (9 + _PPS_SET_D)
+//#define   _PPS_RPXX       (10 + _PPS_SET_D)
+#define _PPS_RPF2       (11 + _PPS_SET_D)
+#define _PPS_RPC2       (12 + _PPS_SET_D)
+#define _PPS_RPE8       (13 + _PPS_SET_D)
+//#define   _PPS_RPXX       (14 + _PPS_SET_D)
+//#define   _PPS_RPXX       (15 + _PPS_SET_D)
 
 #endif
 
 /* ------------------------------------------------------------ */
 
-#endif		// P32_DEFS_H
+#endif      // P32_DEFS_H
 
 //************************************************************************

--- a/hardware/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/hardware/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -1,227 +1,968 @@
-/*
-  SoftwareSerial.cpp - Software serial library
-  Copyright (c) 2006 David A. Mellis.  All right reserved.
+/************************************************************************/
+/*                                                                      */
+/*  SoftwareSerial.cpp --   Main file for Software Serial library       */
+/*                                                                      */
+/************************************************************************/
+/*  Author: Brian Schmalz                                               */
+/*  Copyright 2015, Schmalz Haus LLC. All rights reserved               */
+/************************************************************************/
+/*  File Description:                                                   */
+/*                                                                      */
+/* Header file for Software Serial library.                             */
+/*                                                                      */
+/* This code is based on earlier work:                                  */
+/*      Copyright (c) 2014, Matt Jenkins, Majenko Technology            */
+/*      Copyright (c) 2005, 2006 by David A. Mellis                     */
+/*                                                                      */
+/************************************************************************/
+/*  Revision History:                                                   */
+/*                                                                      */
+/*  05/16/2015(BrianS): Re-written to better imitate existing Arduino   */
+/*  software serial library. Used some existing code from Arduino       */
+/*  as well as quite a bit of code from Matt Jenkins Change Notification*/
+/*  library and Timer Serial library.                                   */
+/*                                                                      */
+/************************************************************************/
+//* This library is free software; you can redistribute it and/or
+//* modify it under the terms of the GNU Lesser General Public
+//* License as published by the Free Software Foundation; either
+//* version 2.1 of the License, or (at your option) any later version.
+//* 
+//* This library is distributed in the hope that it will be useful,
+//* but WITHOUT ANY WARRANTY; without even the implied warranty of
+//* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//* Lesser General Public License for more details.
+//* 
+//* You should have received a copy of the GNU Lesser General
+//* Public License along with this library; if not, write to the
+//* Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+//* Boston, MA  02111-1307  USA
+/************************************************************************/
 
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation; either
-  version 2.1 of the License, or (at your option) any later version.
+/// TODO list in priority order
+/// Set up Change Notice settings for different classes of PIC32 (MX1/2, MZ, etc.)
+/// Calibrate bit-time in terms of core timer tick fudge factor based on clock speed
 
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*/
+/// Handle listen properly
+/// Comment all functions properly
+/// Allow initializer to specify receive buffer size (test)
+/// For slower baud rates (at what baud rate?), keep interrupts on, use core 
+///    timer to sample RX bit rather than tie up CPU for entire byte with 
+///    interrupts off. Or possibly just use CN interrupt to measure time between
+///    transitions, and CoreTimer as timeout if no transitions. 
+/// Use consistent function and variable naming scheme
+/// Handle buffer overflow properly - meaning add an 'overflow_clear' function, 
+///    and have overflow() function not clear _RX_overflow_error.
+/// Add stop bit detection and error detection, and stop bit reporting function
+/// Handle inverted bits properly
 
 /******************************************************************************
  * Includes
  ******************************************************************************/
 
 #include "WConstants.h"
-#include "SoftwareSerial.h"
+#include "SoftwareSerial2.h"
+#include <stdint.h>
+#include <p32xxxx.h>
+#include <sys/attribs.h>
+
+
+/******* DEBUG ************/
+#define SSDEBUG
+#if defined(SSDEBUG)
+    #if defined(_BOARD_FUBARINO_SD_)
+        #define DEBUG0_LOW  TRISDbits.TRISD8 = 0; LATDbits.LATD8 = 0;
+        #define DEBUG0_HIGH TRISDbits.TRISD8 = 0; LATDbits.LATD8 = 1;
+        #define DEBUG1_LOW  TRISDbits.TRISD9 = 0; LATDbits.LATD9 = 0;
+        #define DEBUG1_HIGH TRISDbits.TRISD9 = 0; LATDbits.LATD9 = 1;
+        #define DEBUG2_LOW  TRISDbits.TRISD10 = 0; LATDbits.LATD10 = 0;
+        #define DEBUG2_HIGH TRISDbits.TRISD10 = 0; LATDbits.LATD10 = 1;
+        #define DEBUG3_LOW  TRISDbits.TRISD11 = 0; LATDbits.LATD11 = 0;
+        #define DEBUG3_HIGH TRISDbits.TRISD11 = 0; LATDbits.LATD11 = 1;
+        #define DEBUG4_LOW  TRISDbits.TRISD0 = 0; LATDbits.LATD0 = 0;
+        #define DEBUG4_HIGH TRISDbits.TRISD0 = 0; LATDbits.LATD0 = 1;
+        #define DEBUG5_LOW  TRISCbits.TRISC13 = 0; LATCbits.LATC13 = 0;
+        #define DEBUG5_HIGH TRISCbits.TRISC13 = 0; LATCbits.LATC13 = 1;
+        #define DEBUG6_LOW  TRISCbits.TRISC14 = 0; LATCbits.LATC14 = 0;
+        #define DEBUG6_HIGH TRISCbits.TRISC14 = 0; LATCbits.LATC14 = 1;
+        #define DEBUG7_LOW  TRISDbits.TRISD1 = 0; LATDbits.LATD1 = 0;
+        #define DEBUG7_HIGH TRISDbits.TRISD1 = 0; LATDbits.LATD1 = 1;
+    #elif defined(_BOARD_FUBARINO_MINI_)
+        #define DEBUG0_LOW  TRISBbits.TRISB13 = 0; LATBbits.LATB13 = 0;
+        #define DEBUG0_HIGH TRISBbits.TRISB13 = 0; LATBbits.LATB13 = 1;
+        #define DEBUG1_LOW  TRISAbits.TRISA10 = 0; LATAbits.LATA10 = 0;
+        #define DEBUG1_HIGH TRISAbits.TRISA10 = 0; LATAbits.LATA10 = 1;
+        #define DEBUG2_LOW  TRISAbits.TRISA7 = 0; LATAbits.LATA7 = 0;
+        #define DEBUG2_HIGH TRISAbits.TRISA7 = 0; LATAbits.LATA7 = 1;
+        #define DEBUG3_LOW  TRISBbits.TRISB14 = 0; LATBbits.LATB14 = 0;
+        #define DEBUG3_HIGH TRISBbits.TRISB14 = 0; LATBbits.LATB14 = 1;
+        #define DEBUG4_LOW  TRISBbits.TRISB15 = 0; LATBbits.LATB15 = 0;
+        #define DEBUG4_HIGH TRISBbits.TRISB15 = 0; LATBbits.LATB15 = 1;
+        #define DEBUG5_LOW  TRISAbits.TRISA0 = 0; LATAbits.LATA0 = 0;
+        #define DEBUG5_HIGH TRISAbits.TRISA0 = 0; LATAbits.LATA0 = 1;
+        #define DEBUG6_LOW  TRISAbits.TRISA1 = 0; LATAbits.LATA1 = 0;
+        #define DEBUG6_HIGH TRISAbits.TRISA1 = 0; LATAbits.LATA1 = 1;
+        #define DEBUG7_LOW  TRISBbits.TRISB0 = 0; LATBbits.LATB0 = 0;
+        #define DEBUG7_HIGH TRISBbits.TRISB0 = 0; LATBbits.LATB0 = 1;
+    #else
+        #error No board defined for debug in SoftwareSerial.cpp
+    #endif
+#else
+    #define DEBUG0_LOW
+    #define DEBUG0_HIGH
+    #define DEBUG1_LOW
+    #define DEBUG1_HIGH
+    #define DEBUG2_LOW
+    #define DEBUG2_HIGH
+    #define DEBUG3_LOW
+    #define DEBUG3_HIGH
+    #define DEBUG4_LOW
+    #define DEBUG4_HIGH
+    #define DEBUG5_LOW
+    #define DEBUG5_HIGH
+    #define DEBUG6_LOW
+    #define DEBUG6_HIGH
+    #define DEBUG7_LOW
+    #define DEBUG7_HIGH
+#endif
+
+/**************************/
+
+/******************************************************************************
+ * Statics
+ ******************************************************************************/
+/// TODO: Is this really needed anymore?
+SoftwareSerial *SoftwareSerial::active_object = NULL;
+bool SoftwareSerial::_CN_ISR_hooked = false;
+SoftwareSerial *SoftwareSerial::CN_list_head = NULL;
 
 /******************************************************************************
  * Definitions
  ******************************************************************************/
 
+// Amount of CoreTimer ticks to subtract from 'ideal' bit time to compensate for
+// overhead code.
+#if (F_CPU < 80000000)      // Slower than 80MHz
+    #define EXTRA_RX_BIT_TIME       (-24)
+    #define EXTRA_RX_START_BIT_TIME (-24)
+    #define EXTRA_TX_BIT_TIME       (-18)
+ #elif (F_CPU > 80000000)    // Faster than 80MHz
+    #define EXTRA_RX_BIT_TIME       (-30)
+    #define EXTRA_RX_START_BIT_TIME (-32)
+    #define EXTRA_TX_BIT_TIME       (4)
+#else                       // At 80MHz
+    #define EXTRA_RX_BIT_TIME       (-30)
+    #define EXTRA_RX_START_BIT_TIME (-32)
+    #define EXTRA_TX_BIT_TIME       (4)
+#endif
+
 /******************************************************************************
  * Constructors
  ******************************************************************************/
 
-SoftwareSerial::SoftwareSerial(uint8_t receivePin, uint8_t transmitPin)
+SoftwareSerial::SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverted_logic /* = false */)
 {
-  _receivePin = receivePin;
-  _transmitPin = transmitPin;
-  _baudRate = 0;
+    DEBUG0_LOW
+    DEBUG1_LOW
+    DEBUG2_LOW
+    DEBUG3_LOW
+    DEBUG4_LOW
+    DEBUG5_LOW
+//    delay(100);
+    DEBUG0_HIGH
+    DEBUG1_HIGH
+    DEBUG2_HIGH
+    DEBUG3_HIGH
+    DEBUG4_HIGH
+    DEBUG5_HIGH
+//    delay(100);
+    DEBUG0_LOW
+    DEBUG1_LOW
+    DEBUG2_LOW
+    DEBUG3_LOW
+    DEBUG4_LOW
+    DEBUG5_LOW
+    
+    // Detect if this pin is on a Change Notification or not and record it's CN number if so
+#if !defined(__PIC32_PPS__)
+    if (is_pin_a_CN(receivePin, &(this->_CN_bitmask))
+#else
+    if (is_pin_a_CN(receivePin, NULL))
+#endif    
+    {
+        DEBUG2_HIGH
+        _on_CN_pin = true;
+        addCN();
+    }
+    else 
+    {
+        _on_CN_pin = false;
+    }
+    _inverted_logic = inverted_logic;
+    _receivePin = receivePin;
+    _transmitPin = transmitPin;
+    _baudRate = 0;
+    _have_start_bit_time = false;
+    active_object = this;
+    DEBUG2_LOW
+}
+
+SoftwareSerial::~SoftwareSerial()
+{
+    end();
 }
 
 /******************************************************************************
- * User API
+ * Private functions
  ******************************************************************************/
 
+ /*
+ * ISR function called whenever any Change Notification pins change state.
+ */
+void __attribute__((interrupt)) ChangeNotificationISR() 
+{
+DEBUG5_HIGH
+    // Call the static function that handles all of the CN logic, pass in the current time
+    SoftwareSerial::handleChangeNotificationISR(readCoreTimer());
+DEBUG5_LOW
+    // Clearing the interrupt flag is handled in the above function for PPC CPUs
+#if !defined(__PIC32_PPS__)
+    IFS1bits.CNIF = 0;
+#endif
+}
+
+/*
+ * Look at what's in the SoftwareSerial object obj, and find out if the RX pin that
+ * it points to is set or cleared. Also take into account the _inverted_logic setting.
+ */
+bool SoftwareSerial::ReadBit(SoftwareSerial* obj)
+{
+    bool retval;
+    
+    retval = (obj->_rxPort->port.reg & obj->_rxBit);
+    if (obj->_inverted_logic)
+    {
+        retval = !retval;
+    }
+    if (retval)
+    {
+        DEBUG3_HIGH
+    }
+    else
+    {
+        DEBUG3_LOW
+    }
+    return retval;
+}
+
+/*
+ * This function will look at the current state of the RX bit, and compare it to 
+ * the previous know state, and see if it has changed.
+ * /// TODO: This should cache reads of each port on non-PPS PIC32s somehow so we 
+ * don't end up reading port more than once for a given ISR call.
+ * /// TODO: On PPS PIC32, use CNSTAT register to help with this
+ */
+bool SoftwareSerial::RXBitHasChanged(SoftwareSerial* obj)
+{
+    uint8_t state;
+    
+    state = ReadBit(obj);
+    if (state != obj->_last_RX_pin_state)
+    {
+        obj->_last_RX_pin_state = state;
+        return true;
+    }
+    return false;
+}
+
+/*
+ * Change Notification Interrupt Service Handler
+ * We need to walk through all of the RX serial pins that are on CN pins
+ * to see which ones changed. For any that changed, we call the read() function
+ * to read in a new byte, and store it in the RX buffer.
+ * We also wait around a little bit at the end of the byte to see if there is another
+ * byte coming in back-to-back. If so, we start reading that byte right away rather than
+ * leaving the ISR and coming back in. This allows for more reliable data reception at
+ * higher baud rates.
+ */
+void SoftwareSerial::handleChangeNotificationISR(uint32_t start_bit_time) 
+{
+    int32_t     rx_byte;
+    uint32_t    bit_time_core_ticks;
+    uint32_t    bit_end_time;
+    bool        done = false;
+    SoftwareSerial * serial_obj = SoftwareSerial::CN_list_head;
+    uint32_t    st;
+
+    // To minimize the chance of missing edges at high baud rates, we kill all interrupts
+    st = disableInterrupts();
+
+    // Traverse the linked list of serial objects that use CN pins for their RX.
+    while (serial_obj)
+    {
+DEBUG2_HIGH
+        // Has there been a change since last time through?
+        if (RXBitHasChanged(serial_obj))
+        {
+            // Now that we know this bit has changed AND it is enabled for CN, (because 
+            // it's in the CN linked list) save off it's SoftwareSerial object's start 
+            // bit time from when we were called.
+            serial_obj->_start_bit_time = start_bit_time;
+            serial_obj->_have_start_bit_time = true;
+            // Loop, reading bytes, until there isn't another byte to read in
+            while (!done) 
+            {
+                // Read the whole byte in using the normal routine
+                rx_byte = serial_obj->readByte();
+
+                // If there is still room in the RX buffer, then:
+                if (!serial_obj->_rxBuffer->full())
+                {
+                    // Save the byte off into the buffer
+                    serial_obj->_rxBuffer->write(rx_byte);
+
+                    // We wait for 1 bit time looking for an IDLE to ASSERTED state (indicating the
+                    // front edge of the start bit). If we see one, then this RX channel has more
+                    // data coming back to back with the previous byte, and needs to be handled right
+                    // away.
+                    done = true;
+                    bit_end_time = readCoreTimer() + serial_obj->_OneBitTime + EXTRA_RX_BIT_TIME;
+                    while (readCoreTimer() < bit_end_time) {
+DEBUG4_HIGH
+                        if (ReadBit(serial_obj) == LOW) 
+                        {
+                            done = false;
+                            // Save off the starting time of this start bit
+                            serial_obj->_start_bit_time = readCoreTimer() + 20; // Small fudge factor
+                            // Flag that we have a valid start bit timestamp
+                            serial_obj->_have_start_bit_time = true;
+DEBUG4_LOW
+                            break;
+                        }
+DEBUG4_LOW
+                    }
+                }
+                else
+                {
+                    done = true;
+                }
+            }
+            // Use this to record the latest state of the bit for next time CN fires
+            RXBitHasChanged(serial_obj);
+            
+            // For PPC CPUs, we need to clear the CN interrupt flag. But how to know
+            // which one to clear? Look to see what port our RX bit is on.
+#if defined(__PIC32_PPS__)
+            if ((volatile unsigned int *)serial_obj->_rxPort == &ANSELA)
+            {
+                IFS1bits.CNAIF = 0;
+            }
+            else if ((volatile unsigned int *)serial_obj->_rxPort == &ANSELB)
+            {
+                IFS1bits.CNBIF = 0;
+            }
+            else if ((volatile unsigned int *)serial_obj->_rxPort == &ANSELC)
+            {
+                IFS1bits.CNCIF = 0;
+            }
+#endif
+        }
+        
+        // Advance to the next object in the linked list CN chain
+        serial_obj = serial_obj->next_CN;
+        
+DEBUG2_LOW
+DEBUG4_LOW
+    }
+    restoreInterrupts(st);
+}
+
+/*
+ * Detect if 'pin' is on a Change Notification input or not.
+ * 'pin' is an Arduino pin number. And unfortunately there is
+ * no way to 'look up' if an Arduino pin is on a CN or not.
+ * So the hack here is that we walk through all of the CN_table[]
+ * array looking for a port pointer match and a pin match. If we find
+ * one, then we know that this pin is on a CN, and can return true.
+ */
+bool SoftwareSerial::is_pin_a_CN(uint8_t pin, uint32_t * CN_bitmask)
+{
+#if defined(__PIC32_PPS__)
+    // All pins are CN pins on PPS PIC32s
+    return true;
+#else
+    uint8_t i;
+    
+    for (i = 0; i < NUM_CN; i++) 
+    {
+        if (
+            (digital_pin_to_port_PGM[pin] == CN_table[i].port_index)
+            &&
+            (digital_pin_to_bit_mask_PGM[pin] == CN_table[i].bit_mask)
+        )
+        {
+            *CN_bitmask = 1 << i;
+            return true;
+        }
+    }
+    return false;
+#endif
+}
+
+/*
+ * The real worker function of the library. This function reads in a byte from an arbitrary 
+ * GPIO pin. It gets called from one of two places. If the sketch calls read() and the RX pin
+ * is not a CN pin, then this function will sit and block until a byte is read in on the RX pin.
+ * The other way it gets called is if the RX pin is a CN pin, and a start bit happens, triggering
+ * the CN ISR, then this function gets called to read in the byte that just started appearing on the
+ * RX pin. It disables interrupts to get accurate timing.
+ */ 
+int32_t SoftwareSerial::readByte()
+{    
+    int32_t     retval = 0;
+    uint32_t    st;
+    uint32_t    bit_end_time;
+
+DEBUG0_HIGH
+            
+    if (_baudRate == 0)
+    {
+        _have_start_bit_time = false;
+DEBUG0_LOW
+        return -1;
+    }
+
+DEBUG1_HIGH
+
+    // Wait for start bit if we have not already detected the beginning of the start bit
+    if (!_have_start_bit_time) 
+    {
+        /// TODO: Also, there should be a timeout on this so we don't wait forever.
+        while (ReadBit(this) == HIGH);
+    }
+
+    // We always have to disable interrupts to get our timing right. This SUCKS for
+    // slower baud rates, as sending a back-to-back message will tie up the CPU for 
+    // a really long time.
+    st = disableInterrupts();
+
+    // confirm that this is a real start bit, not line noise
+    if (ReadBit(this) == LOW) 
+    {
+        // frame start indicated by a falling edge and low start bit
+        // jump to the middle of the low start bit
+
+DEBUG1_HIGH
+        if (_have_start_bit_time) 
+        {
+            // If we're getting called from the CN ISR, then we already have the start
+            // time of the start bit in _start_bit_time.
+            bit_end_time = _start_bit_time + (_OneBitTime / 2) + EXTRA_RX_START_BIT_TIME;
+            /// TODO: Do we need to check for bit_end_time being less than _start_bit_time here?
+        }
+        else 
+        {
+            // Need to make this one a big shorter to compensate for the if() above
+            bit_end_time = readCoreTimer() + (_OneBitTime / 2) + EXTRA_RX_START_BIT_TIME;
+        }
+        while (readCoreTimer() < bit_end_time);
+
+DEBUG1_LOW
+        // offset of the bit in the byte: from 0 (LSB) to 7 (MSB)
+        for (int offset = 0; offset < 8; offset++) 
+        {
+            // jump to middle of next bit
+            bit_end_time = readCoreTimer() + _OneBitTime + EXTRA_RX_BIT_TIME;
+            while (readCoreTimer() < bit_end_time);
+DEBUG1_HIGH
+            // read bit
+            retval |= ReadBit(this) << offset;
+DEBUG1_LOW
+        }
+
+        // Wait for 1 more bit time and then check for a stop bit
+        bit_end_time = readCoreTimer() + _OneBitTime + EXTRA_RX_BIT_TIME;
+        while (readCoreTimer() < bit_end_time);
+DEBUG1_HIGH
+        /// Make sure that stop bit is really asserted
+        if (ReadBit(this) == LOW) 
+        {
+            _invalid_stop_bit = true;
+        }   
+DEBUG1_LOW
+    }
+    else 
+    {
+        // If we did not see a real low for a start bit, then this is an error
+        retval = -1;
+    }
+
+    restoreInterrupts(st);
+
+    _have_start_bit_time = false;
+
+DEBUG1_LOW
+DEBUG0_LOW
+
+    return retval;
+}
+
+/*
+ * Add this Software Serial object into the linked list of objects that use Change Notification pins.
+ * If this is the first, then just update the static head pointer.
+ * Otherwise, walk through the list, and add this one at the end.
+ */
+void SoftwareSerial::addCN(void)
+{
+    SoftwareSerial *scan;
+    
+    if (SoftwareSerial::CN_list_head == NULL)
+    {
+        SoftwareSerial::CN_list_head = this;
+        next_CN = NULL;
+    }
+    else
+    {
+        for (scan = SoftwareSerial::CN_list_head; scan->next_CN; scan = scan->next_CN)
+        {
+        }
+        scan->next_CN = this;
+        next_CN = NULL;
+    }
+}
+
+/*
+ * Remove this Software Serial object from the linked list of objects that use Change Notification pins.
+ */
+void SoftwareSerial::removeCN(void)
+{
+    /// TODO
+}
+
+
+/******************************************************************************
+ * Public functions
+ ******************************************************************************/
+
+/*
+ * /// TODO
+ */ 
+bool SoftwareSerial::listen()
+{
+  return false;
+}
+
+/*
+ * /// TODO
+ */ 
+bool SoftwareSerial::stopListening()
+{
+    return false;
+}
+
+/*
+ * Start things up on this serial object with the default RX buffer size 
+ * (only applies if this pin is a CN pin)
+ */ 
 void SoftwareSerial::begin(long speed)
 {
-  _baudRate = speed;
-  _bitPeriod = 1000000 / _baudRate;
-
-  digitalWrite(_transmitPin, HIGH);
-  delayMicroseconds( _bitPeriod); // if we were low this establishes the end
+    begin(speed, TS_BUFSZ);
 }
 
-int SoftwareSerial::read()
+/*
+ * The real begin function. Takes a baud rate (same for RX and TX) and a RX buffer size.
+ * RX buffer size is only used if the RX pin is on a Change Notification pin.
+ */ 
+void SoftwareSerial::begin(long speed, uint32_t RX_buffer_size)
 {
-  int val = 0;
-  int bitDelay = _bitPeriod - clockCyclesToMicroseconds(50);
-  
-  // one byte of serial data (LSB first)
-  // ...--\    /--\/--\/--\/--\/--\/--\/--\/--\/--...
-  //	 \--/\--/\--/\--/\--/\--/\--/\--/\--/
-  //	start  0   1   2   3   4   5   6   7 stop
+    uint8_t     port;
+    uint32_t    st;
+    int32_t     x;
+    int32_t     s;
+    uint32_t    bit_end_time;
 
-  while (digitalRead(_receivePin));
-
-  // confirm that this is a real start bit, not line noise
-  if (digitalRead(_receivePin) == LOW) {
-    // frame start indicated by a falling edge and low start bit
-    // jump to the middle of the low start bit
-    delayMicroseconds(bitDelay / 2 - clockCyclesToMicroseconds(50));
-	
-    // offset of the bit in the byte: from 0 (LSB) to 7 (MSB)
-    for (int offset = 0; offset < 8; offset++) {
-	// jump to middle of next bit
-	delayMicroseconds(bitDelay);
-	
-	// read bit
-	val |= digitalRead(_receivePin) << offset;
+    // We need a new circular buffer object only if we're a CN pin
+    if (_on_CN_pin) {
+        _rxBuffer = new CircularBuffer(_rxBufferArray, RX_buffer_size);
     }
-	
-    delayMicroseconds(_bitPeriod);
     
-    return val;
-  }
-  
-  return -1;
-}
-
-void SoftwareSerial::print(uint8_t b)
-{
-  if (_baudRate == 0)
-    return;
+    _baudRate = speed;
+    _OneBitTime =  ((F_CPU/2)/_baudRate);
     
-  int bitDelay = _bitPeriod - clockCyclesToMicroseconds(50); // a digitalWrite is about 50 cycles
-  byte mask;
+    pinMode(_receivePin, INPUT);
+    pinMode(_transmitPin, OUTPUT);
+    digitalWrite(_transmitPin, HIGH);
 
-  digitalWrite(_transmitPin, LOW);
-  delayMicroseconds(bitDelay);
+    // Wait for at least 2 bit times with the TX pin high, so that our
+    // receiver knows this is the normal state of the line.
+    bit_end_time = readCoreTimer() + _OneBitTime * 2;
+    while (readCoreTimer() < bit_end_time);
 
-  for (mask = 0x01; mask; mask <<= 1) {
-    if (b & mask){ // choose bit
-      digitalWrite(_transmitPin,HIGH); // send 1
+    if ((port = digitalPinToPort(_receivePin)) == NOT_A_PIN) 
+    {
+        return;
     }
-    else{
-      digitalWrite(_transmitPin,LOW); // send 1
+    _rxPort = (p32_ioport *)portRegisters(port);
+    _rxBit = digitalPinToBitMask(_receivePin);
+
+    if ((port = digitalPinToPort(_transmitPin)) == NOT_A_PIN) 
+    {
+        return;
     }
-    delayMicroseconds(bitDelay);
-  }
+    _txPort = (p32_ioport *)portRegisters(port);
+    _txBit = digitalPinToBitMask(_transmitPin);
 
-  digitalWrite(_transmitPin, HIGH);
-  delayMicroseconds(bitDelay);
+
+    // If this is an RX pin on a Change Interrupt pin, turn on the Change Notification interrupt
+    /// Note: This will clobber any other library's use of Change Notification interrupt
+    if (_on_CN_pin) 
+    {
+/// TODO: Make this a function call to asbtract out the CPU differences
+#if !defined(__PIC32_PPS__)
+        // Enable the change notification bit (this was set in contstructor)
+        CNENSET = _CN_bitmask;
+#else
+        CNCONAbits.ON = 1;
+        CNCONBbits.ON = 1;
+        CNCONCbits.ON = 1;
+        CNCONAbits.SIDL = 0;
+        CNCONBbits.SIDL = 0;
+        CNCONCbits.SIDL = 0;
+
+        // On PPS PIC32s, we just set the proper bit in the proper I/O port's CNEN
+        _rxPort->cnen.set = _rxBit;
+        // And turn on that port's CN functionality
+        _rxPort->cncon.reg = 0x8000;    // 'ON' bit in CNCONx register
+        // Do we need to read the whole port here?
+        volatile int tmp = _rxPort->port.reg;
+#endif
+    
+        // Record the current state of this change notification pin (clears mismatch too)
+        _last_RX_pin_state = ReadBit(this); 
+
+        if (!SoftwareSerial::_CN_ISR_hooked)
+        {
+DEBUG0_HIGH
+DEBUG1_HIGH
+            // Configure the change notification interrupt vector
+            setIntVector(_CHANGE_NOTICE_VECTOR, ChangeNotificationISR);
+            // Configure the change notification priority and sub-priority
+            setIntPriority(_CHANGE_NOTICE_VECTOR, 4, 0);
+#if !defined(__PIC32_PPS__)
+            // Clear the change notification interrupt flag
+            clearIntFlag(_CHANGE_NOTICE_IRQ);
+            // And finally enable the change notification interrupt
+            setIntEnable(_CHANGE_NOTICE_IRQ);
+#else
+            // Clear the change notification interrupt flag
+            clearIntFlag(_CHANGE_NOTICE_A_IRQ);
+            clearIntFlag(_CHANGE_NOTICE_B_IRQ);
+            clearIntFlag(_CHANGE_NOTICE_C_IRQ);
+            // And finally enable the change notification interrupt
+            setIntEnable(_CHANGE_NOTICE_A_IRQ);
+            setIntEnable(_CHANGE_NOTICE_B_IRQ);
+            setIntEnable(_CHANGE_NOTICE_C_IRQ);
+#endif
+            
+#if !defined(__PIC32_PPS__)
+            // Turn the whole change notification system on
+            // Set change notification so CPU idle state does not affect it
+            CNCONbits.ON    =   1;
+            CNCONbits.SIDL  =   0;
+#endif            
+            // Mark the ISR as set up so that we don't try to do it again
+            SoftwareSerial::_CN_ISR_hooked = true;
+DEBUG1_LOW
+DEBUG0_LOW
+            }
+    }
+
+    listen();
 }
 
-void SoftwareSerial::print(const char *s)
+/*
+ * We're done with this serial object, so cancel the Change Notification on it's RX
+ * pin (if any) and then stop listening on this RX pin.
+ */ 
+void SoftwareSerial::end()
 {
-  while (*s)
-    print(*s++);
+    if (_on_CN_pin) {
+#if !defined(__PIC32_PPS__)
+        CNEN &= _CN_bitmask;
+#else
+        _rxPort->cnen.clr = _rxBit;
+        // If there are no more bits on this port using CN, then turn off CN for this port
+        if (_rxPort->cnen.reg == 0x0000)
+        {
+            _rxPort->cncon.reg = 0x0000;
+        }
+#endif
+    }
+    removeCN();
+    stopListening();
 }
 
-void SoftwareSerial::print(char c)
+/*
+ * Read a byte from the RX pin.
+ * If this RX pin is on a CN, then read from the RX buffer. If not (it's just a normal
+ * GPIO pin) then block and read a byte from the RX pin.
+ */ 
+int SoftwareSerial::read(void)
 {
-  print((uint8_t) c);
+    if (_on_CN_pin) 
+    {
+        return _rxBuffer->read(); 
+    }
+    else 
+    {
+        return readByte();
+    }
 }
 
-void SoftwareSerial::print(int n)
+/*
+ * This version of the available() function takes a timeout argument in milliseconds.
+ * The idea is to use this version with an RX pin that's not on a Change Notification
+ * pin. Since available() (without a timeout) will always return 1, and most likely then
+ * you'll just go read() (which will wait forever). But if you call this version with 
+ * a timeout, then available() will wait up to timeout_ms milliseconds for a byte to come
+ * in on the RX pin. If it does, then it will return 1. If it does not (in that time) then
+ * it will return 0.
+ */
+int SoftwareSerial::available(uint32_t timeout_ms) 
 {
-  print((long) n);
+    uint32_t end_time_ms = millis() + timeout_ms;
+
+    /// TODO: Is this math OK for millis() rollovers? I don't think so . . .
+    while (end_time_ms > millis())
+    {
+        // Do we have a start bit?
+        if ((_rxPort->port.reg & _rxBit ? HIGH : LOW) == LOW) 
+        {
+            // Save off the starting time of this start bit
+            _start_bit_time = readCoreTimer();
+            _have_start_bit_time = true;
+            // Indicate to the caller that we have a byte to read (in progress)
+            return 1;
+        }
+    }
+    
+    // If we make it this far, then we never saw a start bit
+    return 0;
 }
 
-void SoftwareSerial::print(unsigned int n)
+/*
+ * Return the number of bytes of data currently in the RX buffer.
+ * This only really applies to pins that are CN pins (for RX), because
+ * non-CN pins don't use an RX buffer. We return 1 if we are on a non-CN
+ * RX pin because we want the sketch to think that there is a byte ready to 
+ * read so that it goes and calls read() to read the byte (even if there is none
+ * currently coming in.)
+ */ 
+int SoftwareSerial::available()
 {
-  print((unsigned long) n);
+    if (_on_CN_pin) 
+    {
+        return _rxBuffer->available();
+    }
+    else 
+    {
+        return 1;
+    }
 }
 
-void SoftwareSerial::print(long n)
+/*
+ * Take a byte 'b' and bit-bang it out on the TX pin.
+ * This function blocks until the byte is all the way transmitted. There is no buffering.
+ * Interrupts are disabled for the entire time the byte is being sent out.
+ * Since we always send one byte, we always return a 1.
+ */ 
+size_t SoftwareSerial::write(uint8_t b)
 {
-  if (n < 0) {
-    print('-');
-    n = -n;
-  }
-  printNumber(n, 10);
+    uint32_t    st;
+    uint32_t    bit_end_time;
+#if defined(__PIC32_PPS__)
+    uint32_t    IntEnableA, IntEnableB, IntEnableC;
+#endif
+
+DEBUG0_HIGH
+        
+    byte mask;
+
+    if (_baudRate == 0)
+    {
+        return 0;
+    }
+  
+    // If any software serial objects are on CN pins (for RX) then disable the CN interrupts
+    // while we are transmitting. We have interrupts disabled anyway, so we can't service
+    // any RXing during transmit. And things tend to get confused if we leave the CN on.
+    if(_CN_ISR_hooked == true)
+    {
+#if !defined(__PIC32_PPS__)
+        CNCONbits.ON    =   0;
+#else
+        // The right thing is to only disable those CNxIE bits that we're actually using
+        // Then remember that and restore them when we're done.
+        IntEnableA = clearIntEnable(_CHANGE_NOTICE_A_IRQ);
+        IntEnableB = clearIntEnable(_CHANGE_NOTICE_B_IRQ);
+        IntEnableC = clearIntEnable(_CHANGE_NOTICE_C_IRQ);
+#endif
+    }
+
+    st = disableInterrupts();
+  
+    _txPort->lat.clr = _txBit; // Start bit
+
+DEBUG1_HIGH
+    
+    bit_end_time = readCoreTimer() + _OneBitTime + EXTRA_TX_BIT_TIME;
+    while (readCoreTimer() < bit_end_time);
+
+DEBUG1_LOW
+
+    for (mask = 0x01; mask; mask <<= 1) 
+    {
+        // choose bit
+        if (b & mask)
+        { 
+            _txPort->lat.set = _txBit; // send 1
+        }
+        else
+        {
+            _txPort->lat.clr = _txBit; // send 0
+        }
+        
+DEBUG1_HIGH
+        
+        bit_end_time = readCoreTimer() + _OneBitTime + EXTRA_TX_BIT_TIME;
+        while (readCoreTimer() < bit_end_time);
+        
+DEBUG1_LOW
+
+    }
+
+    _txPort->lat.set = _txBit; // stop bit
+
+DEBUG1_HIGH
+
+    bit_end_time = readCoreTimer() + _OneBitTime + EXTRA_TX_BIT_TIME;
+    while (readCoreTimer() < bit_end_time);
+    
+    restoreInterrupts(st);
+
+    // And restore the CN functions when we're done transmitting this byte
+    if(SoftwareSerial::_CN_ISR_hooked == true)
+    {
+#if !defined(__PIC32_PPS__)
+        CNCONbits.ON    =   1;
+#else
+        // The right thing is to only disable those CNxIE bits that we're actually using
+        // Then remember that and restore them when we're done.
+        restoreIntEnable(_CHANGE_NOTICE_A_IRQ, IntEnableA);
+        restoreIntEnable(_CHANGE_NOTICE_B_IRQ, IntEnableB);
+        restoreIntEnable(_CHANGE_NOTICE_C_IRQ, IntEnableC);
+#endif
+    }
+    
+    return 1;
 }
 
-void SoftwareSerial::print(unsigned long n)
+/* 
+ * Since we do not use buffered transmit in this library, this function
+ * doesn't have much to do.
+ */
+void SoftwareSerial::flush()
 {
-  printNumber(n, 10);
 }
 
-void SoftwareSerial::print(long n, int base)
+/*
+ * If this RX pin is a CN pin (and thus has an RX buffer), peek at the next byte in the buffer and
+ * return it. If this is not a CN pin, then return an error value of -1.
+ */ 
+int SoftwareSerial::peek()
 {
-  if (base == 0)
-    print((char) n);
-  else if (base == 10)
-    print(n);
-  else
-    printNumber(n, base);
+    if (_on_CN_pin)
+    {
+        return _rxBuffer->getEntry(_rxBuffer->getHead());
+    }
+    else
+    {
+        return -1;
+    }
 }
 
-void SoftwareSerial::println(void)
+// Circular buffer support
+
+CircularBuffer::CircularBuffer(uint8_t *buffer, uint32_t size) 
 {
-  print('\r');
-  print('\n');  
+    _size = size;
+    _data = buffer;
+    _head = 0;
+    _tail = 0;
 }
 
-void SoftwareSerial::println(char c)
+CircularBuffer::CircularBuffer(uint32_t size) 
 {
-  print(c);
-  println();  
+    _size = size;
+    _data = (uint8_t *)malloc(size);
+    _head = 0;
+    _tail = 0;
 }
 
-void SoftwareSerial::println(const char c[])
+int32_t CircularBuffer::read() 
 {
-  print(c);
-  println();
+    int16_t chr;
+    if (_head == _tail) 
+    {
+        return -1;
+    }
+    chr = _data[_tail];
+    _tail = (_tail + 1) % _size;
+    return chr;
 }
 
-void SoftwareSerial::println(uint8_t b)
+void CircularBuffer::write(uint8_t d) 
 {
-  print(b);
-  println();
+    uint32_t newhead = (_head + 1) % _size;
+    if (newhead != _tail) 
+    {
+        _data[_head] = d;
+        _head = newhead;
+    }
 }
 
-void SoftwareSerial::println(int n)
+/* Return the number of bytes currently in the circular buffer */
+int32_t CircularBuffer::available() 
 {
-  print(n);
-  println();
+    return (_size + _head - _tail) % _size;
 }
 
-void SoftwareSerial::println(long n)
+/* Return true if buffer is completely full */
+bool CircularBuffer::full() 
 {
-  print(n);
-  println();  
+    return (((_head + 1) % _size) == _tail);
 }
 
-void SoftwareSerial::println(unsigned long n)
+void CircularBuffer::clear() 
 {
-  print(n);
-  println();  
+    _head = _tail = 0;
 }
 
-void SoftwareSerial::println(long n, int base)
+uint8_t CircularBuffer::getEntry(uint32_t p) 
 {
-  print(n, base);
-  println();
+    if (p >= _size) 
+    {
+        return 0;
+    }
+    return _data[p];
 }
 
-// Private Methods /////////////////////////////////////////////////////////////
-
-void SoftwareSerial::printNumber(unsigned long n, uint8_t base)
+uint32_t CircularBuffer::getHead() 
 {
-  unsigned char buf[8 * sizeof(long)]; // Assumes 8-bit chars. 
-  unsigned long i = 0;
+    return _head;
+}
 
-  if (n == 0) {
-    print('0');
-    return;
-  } 
-
-  while (n > 0) {
-    buf[i++] = n % base;
-    n /= base;
-  }
-
-  for (; i > 0; i--)
-    print((char) (buf[i - 1] < 10 ? '0' + buf[i - 1] : 'A' + buf[i - 1] - 10));
+uint32_t CircularBuffer::getTail() 
+{
+    return _tail;
 }

--- a/hardware/pic32/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/hardware/pic32/libraries/SoftwareSerial/SoftwareSerial.h
@@ -1,56 +1,211 @@
-/*
-  SoftwareSerial.h - Software serial library
-  Copyright (c) 2006 David A. Mellis.  All right reserved.
-
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation; either
-  version 2.1 of the License, or (at your option) any later version.
-
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*/
+/************************************************************************/
+/*                                                                      */
+/*  SoftwareSerial.h -- Header file for Software Serial library         */
+/*                                                                      */
+/************************************************************************/
+/*  Author: Brian Schmalz                                               */
+/*  Copyright 2015, Schmalz Haus LLC. All rights reserved               */
+/************************************************************************/
+/*  File Description:                                                   */
+/*                                                                      */
+/* Header file for Software Serial library.                             */
+/*                                                                      */
+/* This code is based on earlier work:                                  */
+/*      Copyright (c) 2014, Matt Jenkins, Majenko Technology            */
+/*      Copyright (c) 2005, 2006 by David A. Mellis                     */
+/*                                                                      */
+/************************************************************************/
+//* This library is free software; you can redistribute it and/or
+//* modify it under the terms of the GNU Lesser General Public
+//* License as published by the Free Software Foundation; either
+//* version 2.1 of the License, or (at your option) any later version.
+//* 
+//* This library is distributed in the hope that it will be useful,
+//* but WITHOUT ANY WARRANTY; without even the implied warranty of
+//* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//* Lesser General Public License for more details.
+//* 
+//* You should have received a copy of the GNU Lesser General
+//* Public License along with this library; if not, write to the
+//* Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+//* Boston, MA  02111-1307  USA
+/************************************************************************/
 
 #ifndef SoftwareSerial_h
 #define SoftwareSerial_h
 
+#define	OPT_SYSTEM_INTERNAL
+#define OPT_BOARD_INTERNAL	//pull in internal symbol definitons
+#if (ARDUINO >= 100)
+# include <Arduino.h>
+#else
+# include <WProgram.h>
+#endif
 #include <inttypes.h>
+#include <Stream.h>
 
-class SoftwareSerial
+
+// The default size of the receive buffer for change notification pin based serial objects
+#define TS_BUFSZ 256
+
+
+#if !defined(__PIC32_PPS__) 
+// Structure holding information about each CN pin on non-PPS PIC32s
+typedef struct {
+    uint16_t bit_mask;          // Bit mask within port of this CN
+    uint8_t port_index;         // Index into port_to_tris_PGM[] of the port this CN is on
+} CN_table_type;
+
+// The total possible number of change notification pins
+// (NOTE: This is only for non-PPS PIC32s.)
+#define NUM_CN 22
+
+// This structure represents the mapping of each Change Notification pin to
+// a port and pin within that port for all PIC32s before PPS was added.
+// For all of these non-PPS PIC32s, the Change Notification (CN) mapping is
+// exactly the same.
+const CN_table_type CN_table[NUM_CN] = {
+    { _BV(14), _IOPORT_PC}, // CN0  - RC14
+    { _BV(13), _IOPORT_PC}, // CN1  - RC13
+    { _BV( 0), _IOPORT_PB}, // CN2  - RB0
+    { _BV( 1), _IOPORT_PB}, // CN3  - RB1
+    { _BV( 2), _IOPORT_PB}, // CN4  - RB2
+    { _BV( 3), _IOPORT_PB}, // CN5  - RB3
+    { _BV( 4), _IOPORT_PB}, // CN6  - RB4
+    { _BV( 5), _IOPORT_PB}, // CN7  - RB5
+    { _BV( 6), _IOPORT_PG}, // CN8  - RG6
+    { _BV( 7), _IOPORT_PG}, // CN9  - RG7
+    { _BV( 8), _IOPORT_PG}, // CN10 - RG8
+    { _BV( 9), _IOPORT_PG}, // CN11 - RG9
+    { _BV(15), _IOPORT_PB}, // CN12 - RB15
+    { _BV( 4), _IOPORT_PD}, // CN13 - RD4
+    { _BV( 5), _IOPORT_PD}, // CN14 - RD5
+    { _BV( 6), _IOPORT_PD}, // CN15 - RD6
+    { _BV( 7), _IOPORT_PD}, // CN16 - RD7
+    { _BV( 4), _IOPORT_PF}, // CN17 - RF4
+    { _BV( 5), _IOPORT_PF}, // CN18 - RF5
+    { _BV(13), _IOPORT_PD}, // CN19 - RD13
+    { _BV(14), _IOPORT_PD}, // CN20 - RD14
+    { _BV(15), _IOPORT_PD}, // CN21 - RD15
+};
+#else
+    #warning Error: Unknown processor type found in SoftwareSerial.h.
+#endif
+
+class CircularBuffer {
+    private:
+        uint8_t *_data;
+        int32_t _head;
+        int32_t _tail;
+        int32_t _size;
+
+    public:
+        CircularBuffer(uint32_t);
+        CircularBuffer(uint8_t *, uint32_t);
+        int32_t read();
+        void write(uint8_t);
+        int32_t available();
+        void clear();
+        uint8_t getEntry(uint32_t p);
+        uint32_t getHead();
+        uint32_t getTail();
+        bool full();
+};
+
+
+class SoftwareSerial : public Stream
 {
   private:
-    uint8_t _receivePin;
-    uint8_t _transmitPin;
-    long _baudRate;
-    int _bitPeriod;
+    // per object data
+    uint8_t     _receivePin;        // Digital pin RX is assigned to
+    uint8_t     _transmitPin;       // Digital pin RX is assigned to
+    long        _baudRate;
+    
+    // Error bit indicating that RX buffer has overflowed and some bytes have been lost
+    uint8_t _RX_buffer_overflow:1;
+    // Error bit that indicates that a valid stop bit was not seen at some point
+    uint8_t _invalid_stop_bit:1;
+    // TRUE if this software serial object uses inverted logic (normally low, start bit is high, etc.)
+    uint8_t _inverted_logic:1;
+    // TRUE if the RX pin of this software serial object is on a Change Notice pin
+    uint8_t _on_CN_pin:1;
+    // TRUE when, for this RX byte, we have already captured and recorded the falling edge of the start bit
+    uint8_t _have_start_bit_time:1;
+    // If this RX pin is on a CN pin and this is a non-PPS CPU, then we store the bitmask of
+    // the CN pin here (for access into CNEN register)
+#if !defined(__PIC32_PPS__)
+    uint32_t _CN_bitmask;
+#endif
+    // Record if we've set up the CN ISR (only need to do it once)
+    //
+    static bool _CN_ISR_hooked;
+    // Records the last known state of this RX pin (when using CN)
+    bool _last_RX_pin_state;
+    // Port and bit mask for our RX pin
+    p32_ioport *_rxPort;
+    uint16_t _rxBit;
+    // Port and bit mask for our TX pin
+    p32_ioport *_txPort;
+    uint16_t _txBit;
+    // Linked list of all SoftwareSerial objects that use Change Notification pins
+    static SoftwareSerial *CN_list_head;
+    SoftwareSerial *next_CN;
+    // Time, in CoreTimer ticks, of a single  bit
+    uint32_t _OneBitTime;
+    
+    // private methods
+    void IntRead(void);
+    bool is_pin_a_CN(uint8_t pin, uint32_t * CN_bitmask);
+    void addCN(void);
+    void removeCN(void);
+    static bool ReadBit(SoftwareSerial*);
+    static bool RXBitHasChanged(SoftwareSerial*);
     void printNumber(unsigned long, uint8_t);
+    
   public:
-    SoftwareSerial(uint8_t, uint8_t);
-    void begin(long);
-    int read();
-    void print(char);
-    void print(const char[]);
-    void print(uint8_t);
-    void print(int);
-    void print(unsigned int);
-    void print(long);
-    void print(unsigned long);
-    void print(long, int);
-    void println(void);
-    void println(char);
-    void println(const char[]);
-    void println(uint8_t);
-    void println(int);
-    void println(long);
-    void println(unsigned long);
-    void println(long, int);
+    // Array to hold circular RX buffer
+    /// TODO: Can this be made private?
+    uint8_t _rxBufferArray[TS_BUFSZ];
+    // Circular buffer object for RX buffer management
+    /// TODO: Can this be made private?
+    CircularBuffer *_rxBuffer;
+
+    // Records the Core Timer value at the start of the start bit
+    /// TODO: Can this be made private?
+    uint32_t _start_bit_time;
+
+    // static data
+    /// TODO: Can this be made private?
+    static SoftwareSerial *active_object;
+
+    // public methods
+    SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverted_logic = false);
+    ~SoftwareSerial();
+    static void handleChangeNotificationISR(uint32_t start_bit_time);
+    void begin(long speed);
+    void begin(long speed, uint32_t RX_buffer_size);
+    bool listen();
+    int32_t readByte(void);
+    void end();
+    bool isListening() { return this == active_object; }
+    bool stopListening();
+    bool overflow() { bool ret = _RX_buffer_overflow; if (ret) _RX_buffer_overflow = false; return ret; }
+
+    // Note: has, to to be int and not int32_t for some reason
+    virtual int available();
+    int available(uint32_t timeout_ms);
+    // Note: has, to to be int and not int32_t for some reason
+    virtual int peek();
+    
+    virtual size_t write(uint8_t byte);
+    // Note: has, to to be int and not int32_t for some reason
+    virtual int read();
+    virtual void flush();
+    explicit operator bool() { return true; }
+    
+    using Print::write;
 };
+
 
 #endif
 

--- a/hardware/pic32/libraries/SoftwareSerial/examples/SoftwareSerialExample/SoftwareSerialExample.ino
+++ b/hardware/pic32/libraries/SoftwareSerial/examples/SoftwareSerialExample/SoftwareSerialExample.ino
@@ -1,0 +1,46 @@
+/*
+  Software serial multple serial test (For chipKIT)
+
+ Receives from the hardware serial, sends to software serial.
+ Receives from software serial, sends to hardware serial.
+
+ The circuit:
+ * RX is digital pin 10 (connect to TX of other device)
+ * TX is digital pin 11 (connect to RX of other device)
+
+ created back in the mists of time
+ modified 25 May 2012
+ by Tom Igoe
+ based on Mikal Hart's example
+ Modified on Aug 31,2015 by Brian Schmalz for chipKIT
+ 
+ This example code is in the public domain.
+
+ */
+#include <SoftwareSerial.h>
+
+SoftwareSerial mySerial(10, 11); // RX, TX
+
+void setup()
+{
+  // Open serial communications and wait for port to open:
+  Serial.begin(57600);
+  while (!Serial) {
+    ;
+  }
+  
+  Serial.println("Goodnight moon!");
+
+  // set the data rate for the SoftwareSerial port
+  mySerial.begin(115200);
+  mySerial.println("Hello, world?");
+}
+
+void loop() // run over and over
+{
+  if (mySerial.available())
+    Serial.write(mySerial.read());
+  if (Serial.available())
+    mySerial.write(Serial.read());
+}
+

--- a/hardware/pic32/libraries/SoftwareSerial/examples/SoftwareSerialMultiByteTest/SoftwareSerialMultiByteTest.ino
+++ b/hardware/pic32/libraries/SoftwareSerial/examples/SoftwareSerialMultiByteTest/SoftwareSerialMultiByteTest.ino
@@ -1,0 +1,71 @@
+/* Software serial mutliple  byte RX and TX test for chipKIT
+
+USB serial, Serial0 (UART1) and SoftwareSerial are all connected
+so that data from the PC goes out Serial1 TX and in Software RX,
+also same data goes out Software TX and in Serial1 RX.
+All data from Serial1 RX and Software RX goes up to PC via USB.
+
+The circuit: 
+ Fubarino Mini
+ * Software TX (11) connect to Serial1 RX (25)
+ * Software RX (10) connect to Serial1 TX (26)
+ 
+ Fubarino SD:
+ * Software TX (11) connect to Serial1 RX (31)
+ * Software RX (10) connect to Serial1 TX (32)
+ 
+ uC32/UNO32:
+ * Software TX (11) connect to Serial1 RX (39)
+ * Software RX (10) connect to Serial1 TX (40)
+
+ Test instructions: Open the serial monitor. Every half second or
+ so you will see a long line containing all of the HEX values from
+ 00 to FF. If any of them are missing or in the wrong order, then
+ the SoftwareSerial receive routines are not working right.
+ 
+ This demo shows that a SoftwareSerial object (on a CN pin) can
+ receive 256 bytes, buffer them all properly, and then the sketch
+ can read in the data later.
+ 
+ This example code is in the public domain. */
+
+#include <SoftwareSerial.h>
+
+SoftwareSerial SoftSerial(10, 11); // RX, TX
+
+void setup() {
+  int32_t i;
+  
+  // Open serial communications and wait for port to open:
+  Serial.begin(57600);
+  while (!Serial) {
+    ;
+  }
+
+  Serial.println("Beginning SoftwareSerial test.");
+  // Open hardware UART port up
+  Serial1.begin(115200);
+  // Open software serial port up
+  SoftSerial.begin(115200);
+  
+}
+
+void loop() {
+  uint16_t i;
+  // Send buffer out Serial1 to be received by SoftSerial
+  for (i=0; i < 256; i++)
+  {
+    Serial1.write(i);
+  }
+  
+  // Now wait a bit for all bytes to be sent
+  delay(500);
+  
+  // And see what's in the SoftSerial RX buffer
+  while (SoftSerial.available()) {
+    Serial.print(SoftSerial.read(), HEX);
+    Serial.print(" ");
+  }
+  Serial.println();
+}
+

--- a/hardware/pic32/libraries/SoftwareSerial/examples/SoftwareSerialSimpleTest/SoftwareSerialSimpleTest.ino
+++ b/hardware/pic32/libraries/SoftwareSerial/examples/SoftwareSerialSimpleTest/SoftwareSerialSimpleTest.ino
@@ -1,0 +1,64 @@
+/* Software serial simple single byte RX and TX test for chipKIT
+
+USB serial, Serial1 (UART1) and SoftwareSerial are all connected
+so that data from the PC goes out Serial1 TX and in Software RX,
+also same data goes out Software TX and in Serial1 RX.
+All data from Serial1 RX and Software RX goes up to PC via USB.
+
+The circuit: 
+ Fubarino Mini
+ * Software TX (11) connect to Serial1 RX (25)
+ * Software RX (10) connect to Serial1 TX (26)
+ 
+ Fubarino SD:
+ * Software TX (11) connect to Serial1 RX (31)
+ * Software RX (10) connect to Serial1 TX (32)
+ 
+ uC32/UNO32:
+ * Software TX (11) connect to Serial1 RX (39)
+ * Software RX (10) connect to Serial1 TX (40)
+ 
+ This example code is in the public domain. */
+
+#include <SoftwareSerial.h>
+
+SoftwareSerial SoftSerial(10, 11); // RX, TX
+
+void setup() {
+  int32_t i;
+  // Open serial communications and wait for port to open:
+  Serial.begin(57600);
+  while (!Serial) {
+    ;
+  }
+
+  Serial.println("Beginning SoftwareSerial test.");
+  // Open hardware UART port up
+  Serial1.begin(115200);
+  // Open software serial port up
+  SoftSerial.begin(115200);
+}
+
+void loop() {
+  // Any bytes that come in on the software serial port, send to USB
+  if (SoftSerial.available()) {
+    Serial.print("S:");
+    Serial.write(SoftSerial.read());
+    Serial.println();
+  }
+  // Any bytes that come in on Serial1, send to USB
+  if (Serial1.available()) {
+    Serial.print("H:");
+    Serial.write(Serial1.read());
+    Serial.println();
+  }
+  // Any bytes that come in on the USB port, send to both Serial1 and SoftwareSerial
+  if (Serial.available()) {
+    char c = Serial.read();
+    Serial1.write(c);
+    // Since we can't send and receive on SoftSerial at the same time, delay this send a bit
+    delay(20);
+    SoftSerial.write(c);
+  }
+}
+

--- a/hardware/pic32/libraries/SoftwareSerial/keywords.txt
+++ b/hardware/pic32/libraries/SoftwareSerial/keywords.txt
@@ -1,5 +1,6 @@
 #######################################
-# Syntax Coloring Map For Ultrasound
+# Syntax Coloring Map for SoftwareSerial
+# (formerly NewSoftSerial)
 #######################################
 
 #######################################
@@ -11,6 +12,17 @@ SoftwareSerial	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
+
+begin	KEYWORD2
+end	KEYWORD2
+read	KEYWORD2
+write	KEYWORD2
+available	KEYWORD2
+isListening	KEYWORD2
+overflow	KEYWORD2
+flush	KEYWORD2
+listen	KEYWORD2
+peek	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/hardware/pic32/libraries/SoftwareSerial/readme.txt
+++ b/hardware/pic32/libraries/SoftwareSerial/readme.txt
@@ -1,0 +1,40 @@
+SoftwareSerial - chipKIT version
+Re-written July 2015 by Brian Schmalz of Schmalz Haus : brian@schmalzhaus.com
+
+
+Change Notification:
+
+The PIC32 processors have a feature called Change Notification. This feature can genrate an interrupt when an edge is seen on a particular pin. In the SoftwareSerial library, we use this Change Nofication feature whenever possible on the RX pin. This allows for an interrupt based receive mechanism so that .available() can work properly and so that the mainline code doesn't need to sit and poll for a received byte.
+
+The PIC32MX1/2 and the PIC32MZ family hve Change Notification available on every pin.
+
+The PIC32MX3/4/5/6/7 families have Change Notification aviailable only on some pins. They are listed here:
+CN0  - RC14
+CN1  - RC13
+CN2  - RB0
+CN3  - RB1
+CN4  - RB2
+CN5  - RB3
+CN6  - RB4
+CN7  - RB5
+CN8  - RG6
+CN9  - RG7
+CN10 - RG8
+CN11 - RG9
+CN12 - RB15
+CN13 - RD4
+CN14 - RD5
+CN15 - RD6
+CN16 - RD7
+CN17 - RF4
+CN18 - RF5
+CN19 - RD13
+CN20 - RD14
+CN21 - RD15
+Since each chipKIT board has these pins mapped to different digial pin numbers, this table can only reference the PIC32 port and bit of the Change Notification pins.
+
+
+
+Notes: Even if the RX pin of a Software Serial object is on a Change Notification pin, sending any data out any Software Serial objects during the reception of any Software Serial data on any Software Serial objects may cause received data corruption. This is because any transmitting from any Software Serial objects disable interrupts for the entire byte time, thus preventing the proper reception of any RX data. Transmitting from any Software Serial object also disables Change Notification detction to prevent firing of the CN interrupt after the data is transmitted if there was a change on a CN input during the transmission. This means that all Software Serial transactions must be half duplex. This rule can be broken if the transmitting baud rate is significantly higher than the receiving baud rate, so that the chance of disabling interrupts during a received edge is very small, thus changing the received timing of the RX byte edges only slightly.
+
+Sometimes .avilable() will be true, but there will no bytes in the buffer. Not sure why this happens, but it's easy to test again for .available() (the second time will always be correct).

--- a/hardware/pic32/libraries/SoftwareSerial/readme.txt
+++ b/hardware/pic32/libraries/SoftwareSerial/readme.txt
@@ -1,6 +1,15 @@
 SoftwareSerial - chipKIT version
 Re-written July 2015 by Brian Schmalz of Schmalz Haus : brian@schmalzhaus.com
 
+CURRENT STATUS : Version 1.0 : August 31st, 2015
+    Work in progress. All example sketches compmile for all chipKIT boards, and run properly 
+    at 115200 and 300 baud. But there is functionality that is not yet implemented, and many
+    optomizations left to be coded and tested (see top of .cpp file for TODO list). Main
+    problem is that even at lower baud rates, we always turn off all interrupts for the whole
+    system any time we transmit or receive a byte. This really messes with anything that needs
+    interrupts to run. Also it's not possible currently to transmit and recieve at the same time
+    on any software serial objects. So, as far as software serial objects are concerned, everything
+    must be kept half duplex.
 
 Change Notification:
 
@@ -38,3 +47,7 @@ Since each chipKIT board has these pins mapped to different digial pin numbers, 
 Notes: Even if the RX pin of a Software Serial object is on a Change Notification pin, sending any data out any Software Serial objects during the reception of any Software Serial data on any Software Serial objects may cause received data corruption. This is because any transmitting from any Software Serial objects disable interrupts for the entire byte time, thus preventing the proper reception of any RX data. Transmitting from any Software Serial object also disables Change Notification detction to prevent firing of the CN interrupt after the data is transmitted if there was a change on a CN input during the transmission. This means that all Software Serial transactions must be half duplex. This rule can be broken if the transmitting baud rate is significantly higher than the receiving baud rate, so that the chance of disabling interrupts during a received edge is very small, thus changing the received timing of the RX byte edges only slightly.
 
 Sometimes .avilable() will be true, but there will no bytes in the buffer. Not sure why this happens, but it's easy to test again for .available() (the second time will always be correct).
+
+Reception of higher baud rates (can't know exactly - depends on what else is running) will be unreliable. This is because some other interrupt can fire, and prevent the Change Noficiation ISR from gettin control before the start bit is complete. If this happens, the CN ISR checks to see if there still a start bit, and can find that the RX pin is high (i.e. start bit complete) and it then has no idea where the byte started in time. This will generate incorrect byte values every now and then.
+
+Baud Rates: Baud rates at 230,400 and beyond have been tested for transmission, and do work, although that speed is right on the edge of what a 48MHz chipKIT can handle. As the baud rate gets higher, the chance of missing the start bit increases. As the baud rate goes lower, the interrupts are disabled for longer and longer (during every send and receive operation), so that's a trade off as well. For RX, baud rates of 115,200 is about as high as you can go on a 48Mhz chipKIT. Faster speeds work fine on fater boards.

--- a/hardware/pic32/variants/Fubarino_SD/Board_Defs.h
+++ b/hardware/pic32/variants/Fubarino_SD/Board_Defs.h
@@ -193,25 +193,25 @@ const static uint8_t SCK  = 24;		// PIC32 SCK2
 /* These define the pin numbers for the various change notice
 ** pins.
 */
-#define	PIN_CN0		7
-#define	PIN_CN1		6
-#define	PIN_CN2		33
-#define	PIN_CN3		32
-#define	PIN_CN4		31
-#define	PIN_CN5		30
-#define	PIN_CN6		29
-#define	PIN_CN7		28
-#define	PIN_CN8		24
-#define	PIN_CN9		25
-#define	PIN_CN10	26
-#define	PIN_CN11	27
-#define	PIN_CN12	44
-#define	PIN_CN13	10
-#define	PIN_CN14	11
-#define	PIN_CN15	12
-#define	PIN_CN16	13
-#define	PIN_CN17	28
-#define	PIN_CN18	29
+#define	PIN_CN0		6       // RC14
+#define	PIN_CN1		5       // RC13
+#define	PIN_CN2		34      // RB0
+#define	PIN_CN3		33      // RB1
+#define	PIN_CN4		32      // RB2
+#define	PIN_CN5		31      // RB3
+#define	PIN_CN6		30      // RB4
+/* RB5 not brought out on Fubarino SD */ // #define	PIN_CN7		29 // RB5
+#define	PIN_CN8		24      // RG6
+#define	PIN_CN9		25      // RG7
+#define	PIN_CN10	26      // RG8
+#define	PIN_CN11	27      // RG9
+#define	PIN_CN12	44      // RB15
+#define	PIN_CN13	10      // RD4
+#define	PIN_CN14	11      // RD5
+#define	PIN_CN15	12      // RD6
+#define	PIN_CN16	13      // RD7
+#define	PIN_CN17	28      // RF4
+#define	PIN_CN18	29      // RF5
 
 /* ------------------------------------------------------------ */
 /*					Pin Mapping Macros							*/


### PR DESCRIPTION
This new Software Serial library works properly on all chipKIT boards at up to 115200 (or higher) baud, and is compatible with the Arduino 1.6.x Software Serial object hierarchy. 

Note that some functions are not completely filled out yet, but the basic functionality exists and has been tested on all classes of chipKIT boards - Non-PPS MX (uC32, UNO32, MAX32), PPS MX (Fubarino Mini, DP32, chipKIT Pi), and MZ (WiFire).

See the included readme.txt for more technical details about some potential issues with this library. 