### PR TITLE
Added system folder support

### DIFF
--- a/build/shared/examples/3.Analog/Smoothing/Smoothing.pde
+++ b/build/shared/examples/3.Analog/Smoothing/Smoothing.pde
@@ -27,7 +27,7 @@
 const int numReadings = 10;
 
 int readings[numReadings];      // the readings from the analog input
-int index = 0;                  // the index of the current reading
+int sampleIndex = 0;                  // the index of the current reading
 int total = 0;                  // the running total
 int average = 0;                // the average
 
@@ -44,18 +44,18 @@ void setup()
 
 void loop() {
   // subtract the last reading:
-  total= total - readings[index];         
+  total= total - readings[sampleIndex];         
   // read from the sensor:  
-  readings[index] = analogRead(inputPin); 
+  readings[sampleIndex] = analogRead(inputPin); 
   // add the reading to the total:
-  total= total + readings[index];       
+  total= total + readings[sampleIndex];       
   // advance to the next position in the array:  
-  index = index + 1;                    
+  sampleIndex = sampleIndex + 1;                    
 
   // if we're at the end of the array...
-  if (index >= numReadings)              
+  if (sampleIndex >= numReadings)              
     // ...wrap around to the beginning: 
-    index = 0;                           
+    sampleIndex = 0;                           
 
   // calculate the average:
   average = total / numReadings;         

--- a/hardware/pic32/platforms.txt
+++ b/hardware/pic32/platforms.txt
@@ -2,7 +2,7 @@
 pic32.recipe.c.o.pattern={0}{1}::{2}::{3}{4}::-DF_CPU={5}::-D{6}::-D{7}::{8}::{9}::{10}::-o::{11}
 pic32.recipe.cpp.o.pattern={0}{1}::{2}::{3}{4}::-DF_CPU={5}::-D{6}::-D{7}::{8}::{9}::{10}::-o::{11}
 pic32.recipe.ar.pattern={0}{1}::{2}::{3}{4}::{5}
-pic32.recipe.c.combine.pattern={0}{1}::{2}::{3}{4}::-o::{5}{6}.elf::{7}::{8}::-L{9}::-lm::-T::{10}/{11}::-T{12}/{13}
+pic32.recipe.c.combine.pattern={0}{1}::{2}::{3}{4}::-o::{5}{6}.elf::{7}::{8}::{9}::-L{10}::-lm::-T::{11}/{12}::-T{13}/{14}
 pic32.recipe.objcopy.eep.pattern={0}{1}::{2}::{3}.elf::{4}.eep
 pic32.recipe.objcopy.hex.pattern={0}{1}::{2}::{3}.elf
 


### PR DESCRIPTION
The IDE will now compile an optional folder called `hardware/<core name>/system` into a file `system.a` and link it with the rest of the sketch after `core.a` in the linker command line.

# IMPORTANT (RICK)

Note the additional parameter in the linker command line in platforms.txt that will need to be copied over to chipKIT-core.